### PR TITLE
Use groupId for sample sources in archetype

### DIFF
--- a/stage-lib-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/stage-lib-archetype/src/main/resources/archetype-resources/pom.xml
@@ -33,6 +33,7 @@
     <dependency>
       <groupId>com.streamsets</groupId>
       <artifactId>streamsets-datacollector-api</artifactId>
+      <version>\${streamsets.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/stage-lib-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/stage-lib-archetype/src/main/resources/archetype-resources/pom.xml
@@ -33,7 +33,6 @@
     <dependency>
       <groupId>com.streamsets</groupId>
       <artifactId>streamsets-datacollector-api</artifactId>
-      <version>1.1.0</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/stage-lib-archetype/src/main/resources/archetype-resources/src/main/java/stage/origin/sample/SampleSource.java
+++ b/stage-lib-archetype/src/main/resources/archetype-resources/src/main/java/stage/origin/sample/SampleSource.java
@@ -19,7 +19,7 @@
  */
 package ${groupId}.stage.origin.sample;
 
-import com.adamkunicki.streamsets.stage.lib.sample.Errors;
+import ${groupId}.stage.lib.sample.Errors;
 import com.streamsets.pipeline.api.BatchMaker;
 import com.streamsets.pipeline.api.Field;
 import com.streamsets.pipeline.api.Record;

--- a/stage-lib-archetype/src/main/resources/archetype-resources/src/test/java/stage/destination/sample/TestSampleTarget.java
+++ b/stage-lib-archetype/src/main/resources/archetype-resources/src/test/java/stage/destination/sample/TestSampleTarget.java
@@ -20,7 +20,7 @@
 package ${groupId}.stage.destination.sample;
 
 import _ss_com.com.google.common.collect.ImmutableList;
-import com.adamkunicki.streamsets.stage.destination.sample.SampleTarget;
+import ${groupId}.stage.destination.sample.SampleTarget;
 import com.streamsets.pipeline.api.Field;
 import com.streamsets.pipeline.api.Record;
 import com.streamsets.pipeline.sdk.RecordCreator;

--- a/stage-lib-archetype/src/main/resources/archetype-resources/src/test/java/stage/origin/sample/TestSampleSource.java
+++ b/stage-lib-archetype/src/main/resources/archetype-resources/src/test/java/stage/origin/sample/TestSampleSource.java
@@ -19,7 +19,7 @@
  */
 package ${groupId}.stage.origin.sample;
 
-import com.adamkunicki.streamsets.stage.origin.sample.SampleSource;
+import ${groupId}.stage.origin.sample.SampleSource;
 import com.streamsets.pipeline.api.Record;
 import com.streamsets.pipeline.sdk.SourceRunner;
 import com.streamsets.pipeline.sdk.StageRunner;


### PR DESCRIPTION
I don't know enough about maven to know if `${packageInPathFormat}` is preferred.