### PR TITLE
Scripted Upserts with Elasticsearch Destination

### DIFF
--- a/elasticsearch-protolib/pom.xml
+++ b/elasticsearch-protolib/pom.xml
@@ -125,7 +125,6 @@
       <version>${httpclient.version}</version>
       <scope>compile</scope>
     </dependency>
-
   </dependencies>
 
   <build>

--- a/elasticsearch-protolib/pom.xml
+++ b/elasticsearch-protolib/pom.xml
@@ -125,6 +125,7 @@
       <version>${httpclient.version}</version>
       <scope>compile</scope>
     </dependency>
+
   </dependencies>
 
   <build>

--- a/elasticsearch-protolib/src/main/java/com/streamsets/pipeline/stage/destination/elasticsearch/ElasticSearchConfigBean.java
+++ b/elasticsearch-protolib/src/main/java/com/streamsets/pipeline/stage/destination/elasticsearch/ElasticSearchConfigBean.java
@@ -208,7 +208,7 @@ public class ElasticSearchConfigBean {
       required = false,
       type = ConfigDef.Type.STRING,
       label = "Script ID/Inline/File",
-      defaultValue = "my_custom_script",
+      defaultValue = "",
       description = "An expression which evaluates to the ID of a stored script, the content of an inline script or the filename of a script.",
       dependsOn = "upsert",
       triggeredByValue = "true",

--- a/elasticsearch-protolib/src/main/java/com/streamsets/pipeline/stage/destination/elasticsearch/ElasticSearchConfigBean.java
+++ b/elasticsearch-protolib/src/main/java/com/streamsets/pipeline/stage/destination/elasticsearch/ElasticSearchConfigBean.java
@@ -28,6 +28,7 @@ import com.streamsets.pipeline.lib.el.DataUtilEL;
 import com.streamsets.pipeline.lib.el.RecordEL;
 import com.streamsets.pipeline.lib.el.TimeEL;
 import com.streamsets.pipeline.lib.el.TimeNowEL;
+import org.elasticsearch.script.ScriptService.ScriptType;
 
 import java.util.List;
 import java.util.Map;
@@ -202,4 +203,61 @@ public class ElasticSearchConfigBean {
       group = "ELASTIC_SEARCH"
   )
   public boolean upsert;
+
+  @ConfigDef(
+      required = false,
+      type = ConfigDef.Type.STRING,
+      label = "Script ID/Inline/File",
+      defaultValue = "my_custom_script",
+      description = "An expression which evaluates to the ID of a stored script, the content of an inline script or the filename of a script.",
+      dependsOn = "upsert",
+      triggeredByValue = "true",
+      displayPosition = 10,
+      group = "SCRIPTED_UPSERT",
+      elDefs = {RecordEL.class, DataUtilEL.class},
+      evaluation = ConfigDef.Evaluation.EXPLICIT
+  )
+  public String upsertScript;
+
+  @ConfigDef(
+          required = false,
+          type = ConfigDef.Type.MODEL,
+          defaultValue = "INDEXED",
+          description = "The type of script to run. Make sure script.inline, script.indexed, script.file are set to 'true' in your ElasticSearch config.",
+          label = "Script Type",
+          dependsOn = "upsert",
+          triggeredByValue = "true",
+          displayPosition = 20,
+          group = "SCRIPTED_UPSERT"
+  )
+  @ValueChooserModel(UpsertScriptTypeChooserValues.class)
+  public ScriptType scriptType;
+
+  @ConfigDef(
+      required = false,
+      type = ConfigDef.Type.MODEL,
+      defaultValue = "GROOVY",
+      label = "Script Language",
+      dependsOn = "upsert",
+      triggeredByValue = "true",
+      displayPosition = 30,
+      group = "SCRIPTED_UPSERT"
+  )
+  @ValueChooserModel(UpsertScriptLanguageChooserValues.class)
+  public String scriptLanguage;
+
+  @ConfigDef(
+      required = false,
+      type = ConfigDef.Type.MAP,
+      defaultValue = "{ }",
+      label = "Script Parameters",
+      dependsOn = "upsert",
+      description = "Parameter names and expressions that evaluate to values passed to the script as parameters",
+      triggeredByValue = "true",
+      displayPosition = 40,
+      group = "SCRIPTED_UPSERT",
+      elDefs = {RecordEL.class, DataUtilEL.class},
+      evaluation = ConfigDef.Evaluation.EXPLICIT
+  )
+  public Map<String, String> scriptParams;
 }

--- a/elasticsearch-protolib/src/main/java/com/streamsets/pipeline/stage/destination/elasticsearch/ElasticSearchTarget.java
+++ b/elasticsearch-protolib/src/main/java/com/streamsets/pipeline/stage/destination/elasticsearch/ElasticSearchTarget.java
@@ -48,6 +48,7 @@ import org.elasticsearch.action.bulk.BulkItemResponse;
 import org.elasticsearch.action.bulk.BulkRequestBuilder;
 import org.elasticsearch.action.bulk.BulkResponse;
 import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.indexedscripts.get.GetIndexedScriptResponse;
 import org.elasticsearch.action.update.UpdateRequest;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.xcontent.XContentType;
@@ -350,6 +351,26 @@ public class ElasticSearchTarget extends BaseTarget {
                     Errors.ELASTICSEARCH_30,
                     "indexed",
                     node.getNode().getHostName()
+                )
+            );
+          }
+        }
+
+        if (issues.isEmpty() && conf.scriptType.equals(ScriptService.ScriptType.INDEXED)) {
+          // Verify indexed script exists
+          GetIndexedScriptResponse script_res = elasticClient.prepareGetIndexedScript()
+              .setScriptLang(conf.scriptLanguage.toLowerCase())
+              .setId(conf.upsertScript)
+              .execute().actionGet();
+
+          if (! script_res.isExists()) {
+            issues.add(
+                getContext().createConfigIssue(
+                    Groups.SCRIPTED_UPSERT.name(),
+                    ElasticSearchConfigBean.CONF_PREFIX + "upsertScript",
+                    Errors.ELASTICSEARCH_31,
+                    conf.scriptLanguage.toLowerCase(),
+                    conf.upsertScript
                 )
             );
           }

--- a/elasticsearch-protolib/src/main/java/com/streamsets/pipeline/stage/destination/elasticsearch/Errors.java
+++ b/elasticsearch-protolib/src/main/java/com/streamsets/pipeline/stage/destination/elasticsearch/Errors.java
@@ -50,6 +50,7 @@ public enum Errors implements ErrorCode {
   ELASTICSEARCH_20("Invalid Shield user, it must be <USERNAME>:<PASSWORD>: '{}'"),
 
   ELASTICSEARCH_30("Elasticsearch config: 'es.script.{}=true' is not set on data node '{}'"),
+  ELASTICSEARCH_31("Indexed {} script not found: '{}'"),
   ;
   private final String msg;
 

--- a/elasticsearch-protolib/src/main/java/com/streamsets/pipeline/stage/destination/elasticsearch/Errors.java
+++ b/elasticsearch-protolib/src/main/java/com/streamsets/pipeline/stage/destination/elasticsearch/Errors.java
@@ -38,6 +38,7 @@ public enum Errors implements ErrorCode {
   ELASTICSEARCH_11("Could not connect to the cluster HTTP endpoint: {}"),
   ELASTICSEARCH_12("Could not get the cluster version from HTTP response: {}"),
   ELASTICSEARCH_13("Stage library version '{}' and cluster version '{}' are not compatible"),
+  ELASTICSEARCH_14("Scripted upserts for stage library version '{}' and cluster version '{}' are currently not supported."),
 
   ELASTICSEARCH_15("Could not write record '{}': {}"),
   ELASTICSEARCH_16("Could not index record '{}': {}"),
@@ -47,6 +48,8 @@ public enum Errors implements ErrorCode {
   ELASTICSEARCH_19("Document ID expression must be provided to use the upsert option"),
 
   ELASTICSEARCH_20("Invalid Shield user, it must be <USERNAME>:<PASSWORD>: '{}'"),
+
+  ELASTICSEARCH_30("Elasticsearch config: 'es.script.{}=true' is not set on data node '{}'"),
   ;
   private final String msg;
 

--- a/elasticsearch-protolib/src/main/java/com/streamsets/pipeline/stage/destination/elasticsearch/UpsertScriptLanguage.java
+++ b/elasticsearch-protolib/src/main/java/com/streamsets/pipeline/stage/destination/elasticsearch/UpsertScriptLanguage.java
@@ -23,19 +23,29 @@ import com.streamsets.pipeline.api.GenerateResourceBundle;
 import com.streamsets.pipeline.api.Label;
 
 @GenerateResourceBundle
-public enum Groups implements Label {
-  ELASTIC_SEARCH("Elasticsearch"),
-  SHIELD("Shield"),
-  SCRIPTED_UPSERT("Scripted Upsert"),
+public enum UpsertScriptLanguage implements Label {
+  GROOVY("groovy", "groovy"),
+  EXPRESSION("expression", "expression"),
+  MUSTACHE("mustache", "mustache"),
+  JAVASCRIPT("javascript", "javascript"),
+  PYTHON("python", "python")
   ;
 
   private final String label;
-  Groups(String label) {
+  private final String languageName;
+
+  UpsertScriptLanguage(String label, String languageName) {
     this.label = label;
+    this.languageName = languageName;
   }
 
   @Override
   public String getLabel() {
     return label;
   }
+
+  public String getLanguageName() {
+    return languageName;
+  }
+
 }

--- a/elasticsearch-protolib/src/main/java/com/streamsets/pipeline/stage/destination/elasticsearch/UpsertScriptLanguageChooserValues.java
+++ b/elasticsearch-protolib/src/main/java/com/streamsets/pipeline/stage/destination/elasticsearch/UpsertScriptLanguageChooserValues.java
@@ -19,23 +19,12 @@
  */
 package com.streamsets.pipeline.stage.destination.elasticsearch;
 
-import com.streamsets.pipeline.api.GenerateResourceBundle;
-import com.streamsets.pipeline.api.Label;
+import com.streamsets.pipeline.api.base.BaseEnumChooserValues;
 
-@GenerateResourceBundle
-public enum Groups implements Label {
-  ELASTIC_SEARCH("Elasticsearch"),
-  SHIELD("Shield"),
-  SCRIPTED_UPSERT("Scripted Upsert"),
-  ;
+public class UpsertScriptLanguageChooserValues extends BaseEnumChooserValues {
 
-  private final String label;
-  Groups(String label) {
-    this.label = label;
+  public UpsertScriptLanguageChooserValues() {
+    super(UpsertScriptLanguage.class);
   }
 
-  @Override
-  public String getLabel() {
-    return label;
-  }
 }

--- a/elasticsearch-protolib/src/main/java/com/streamsets/pipeline/stage/destination/elasticsearch/UpsertScriptType.java
+++ b/elasticsearch-protolib/src/main/java/com/streamsets/pipeline/stage/destination/elasticsearch/UpsertScriptType.java
@@ -21,21 +21,30 @@ package com.streamsets.pipeline.stage.destination.elasticsearch;
 
 import com.streamsets.pipeline.api.GenerateResourceBundle;
 import com.streamsets.pipeline.api.Label;
+import org.elasticsearch.script.ScriptService.ScriptType;
 
 @GenerateResourceBundle
-public enum Groups implements Label {
-  ELASTIC_SEARCH("Elasticsearch"),
-  SHIELD("Shield"),
-  SCRIPTED_UPSERT("Scripted Upsert"),
-  ;
+public enum UpsertScriptType implements Label {
+    INDEXED("indexed", ScriptType.INDEXED),
+    INLINE("inline", ScriptType.INLINE),
+    FILE("file", ScriptType.FILE)
+    ;
 
-  private final String label;
-  Groups(String label) {
-    this.label = label;
-  }
+    private final String label;
+    private final ScriptType scriptType;
 
-  @Override
-  public String getLabel() {
-    return label;
-  }
+    UpsertScriptType(String label, ScriptType scriptType) {
+        this.label = label;
+        this.scriptType = scriptType;
+    }
+
+    @Override
+    public String getLabel() {
+        return label;
+    }
+
+    public ScriptType getScriptTypeValue() {
+        return scriptType;
+    }
+
 }

--- a/elasticsearch-protolib/src/main/java/com/streamsets/pipeline/stage/destination/elasticsearch/UpsertScriptTypeChooserValues.java
+++ b/elasticsearch-protolib/src/main/java/com/streamsets/pipeline/stage/destination/elasticsearch/UpsertScriptTypeChooserValues.java
@@ -19,23 +19,12 @@
  */
 package com.streamsets.pipeline.stage.destination.elasticsearch;
 
-import com.streamsets.pipeline.api.GenerateResourceBundle;
-import com.streamsets.pipeline.api.Label;
+import com.streamsets.pipeline.api.base.BaseEnumChooserValues;
 
-@GenerateResourceBundle
-public enum Groups implements Label {
-  ELASTIC_SEARCH("Elasticsearch"),
-  SHIELD("Shield"),
-  SCRIPTED_UPSERT("Scripted Upsert"),
-  ;
+public class UpsertScriptTypeChooserValues extends BaseEnumChooserValues {
 
-  private final String label;
-  Groups(String label) {
-    this.label = label;
-  }
+    public UpsertScriptTypeChooserValues() {
+        super(UpsertScriptType.class);
+    }
 
-  @Override
-  public String getLabel() {
-    return label;
-  }
 }

--- a/elasticsearch-protolib/src/test/java/com/streamsets/pipeline/stage/destination/elasticsearch/TestElasticSearchTarget.java
+++ b/elasticsearch-protolib/src/test/java/com/streamsets/pipeline/stage/destination/elasticsearch/TestElasticSearchTarget.java
@@ -36,6 +36,7 @@ import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.node.Node;
 import org.elasticsearch.node.NodeBuilder;
+import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.search.SearchHit;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -189,6 +190,10 @@ public class TestElasticSearchTarget {
     conf.upsert = upsert;
     conf.useShield = false;
     conf.shieldConfigBean = new ShieldConfigBean();
+    conf.upsertScript = "";
+    conf.scriptType = ScriptService.ScriptType.INDEXED;
+    conf.scriptLanguage = "groovy";
+    conf.scriptParams = Collections.EMPTY_MAP;
 
     return new ElasticSearchTarget(conf);
   }
@@ -506,6 +511,10 @@ public class TestElasticSearchTarget {
     conf.upsert = true; // enable upsert
     conf.useShield = false;
     conf.shieldConfigBean = new ShieldConfigBean();
+    conf.upsertScript = "";
+    conf.scriptType = ScriptService.ScriptType.INDEXED;
+    conf.scriptLanguage = "groovy";
+    conf.scriptParams = Collections.EMPTY_MAP;
 
     ElasticSearchTarget target = new ElasticSearchTarget(conf);
     TargetRunner runner = new TargetRunner.Builder(ElasticSearchDTarget.class, target).build();
@@ -554,4 +563,195 @@ public class TestElasticSearchTarget {
     }
   }
 
+  @Test
+  public void testScriptedUpsertConfigUpdateError() throws Exception {
+    esServer.close();
+
+    File esDir = new File("target", UUID.randomUUID().toString());
+    Map<String, Object> configs = new HashMap<>();
+    configs.put("cluster.name", esName);
+    configs.put("http.enabled", true);
+    configs.put("http.port", esHttpPort);
+    configs.put("transport.tcp.port", esPort);
+    configs.put("path.home", esDir.getAbsolutePath());
+    configs.put("path.conf", esDir.getAbsolutePath());
+    configs.put("path.data", esDir.getAbsolutePath());
+    configs.put("path.logs", esDir.getAbsolutePath());
+    configs.put("script.update", false);
+    configs.put("script.inline", false);
+    configs.put("script.file", false);
+    configs.put("script.indexed", false);
+
+    esServer = NodeBuilder.nodeBuilder().settings(ElasticSearchFactory.settings(configs)).build();
+    esServer.start();
+
+    ElasticSearchConfigBean conf = new ElasticSearchConfigBean();
+    conf.clusterName = esName;
+    conf.uris = ImmutableList.of("127.0.0.1:" + esPort);
+    conf.httpUri = "127.0.0.1:" + esHttpPort;
+    conf.configs = Collections.EMPTY_MAP;
+    conf.timeDriver = "${time:now()}";
+    conf.timeZoneID = "UTC";
+    conf.indexTemplate = "${YYYY()}";
+    conf.typeTemplate = "${record:value('/type')}";
+    conf.docIdTemplate = "${record:value('/index')}"; // Use the index field as document ID.
+    conf.charset = "UTF-8";
+    conf.upsert = true; // enable upsert
+    conf.useShield = false;
+    conf.shieldConfigBean = new ShieldConfigBean();
+    conf.upsertScript = "ctx._source.counter += 2";
+    conf.scriptLanguage = "groovy";
+    conf.scriptParams = Collections.EMPTY_MAP;
+
+    // Verify error when es.script.update is not set.
+    conf.scriptType = ScriptService.ScriptType.INLINE;
+    ElasticSearchTarget target = new ElasticSearchTarget(conf);
+    TargetRunner runner = new TargetRunner.Builder(ElasticSearchDTarget.class, target).build();
+    List<Stage.ConfigIssue> issues = runner.runValidateConfigs();
+    Assert.assertEquals(2, issues.size());
+    Assert.assertTrue(issues.get(0).toString().contains(Errors.ELASTICSEARCH_30.name()));
+    Assert.assertTrue(issues.get(0).toString().contains("es.script.update"));
+    Assert.assertTrue(issues.get(1).toString().contains(Errors.ELASTICSEARCH_30.name()));
+    Assert.assertTrue(issues.get(1).toString().contains("es.script.inline"));
+  }
+
+  @Test
+  public void testScriptedUpsertScriptTypeErrors() throws Exception {
+    esServer.close();
+
+    File esDir = new File("target", UUID.randomUUID().toString());
+    Map<String, Object> configs = new HashMap<>();
+    configs.put("cluster.name", esName);
+    configs.put("http.enabled", true);
+    configs.put("http.port", esHttpPort);
+    configs.put("transport.tcp.port", esPort);
+    configs.put("path.home", esDir.getAbsolutePath());
+    configs.put("path.conf", esDir.getAbsolutePath());
+    configs.put("path.data", esDir.getAbsolutePath());
+    configs.put("path.logs", esDir.getAbsolutePath());
+    configs.put("script.update", true);
+    configs.put("script.inline", false);
+    configs.put("script.file", false);
+    configs.put("script.indexed", false);
+
+    esServer = NodeBuilder.nodeBuilder().settings(ElasticSearchFactory.settings(configs)).build();
+    esServer.start();
+
+    ElasticSearchConfigBean conf = new ElasticSearchConfigBean();
+    conf.clusterName = esName;
+    conf.uris = ImmutableList.of("127.0.0.1:" + esPort);
+    conf.httpUri = "127.0.0.1:" + esHttpPort;
+    conf.configs = Collections.EMPTY_MAP;
+    conf.timeDriver = "${time:now()}";
+    conf.timeZoneID = "UTC";
+    conf.indexTemplate = "${YYYY()}";
+    conf.typeTemplate = "${record:value('/type')}";
+    conf.docIdTemplate = "${record:value('/index')}"; // Use the index field as document ID.
+    conf.charset = "UTF-8";
+    conf.upsert = true; // enable upsert
+    conf.useShield = false;
+    conf.shieldConfigBean = new ShieldConfigBean();
+    conf.upsertScript = "ctx._source.counter += 2";
+    conf.scriptLanguage = "groovy";
+    conf.scriptParams = Collections.EMPTY_MAP;
+
+    // Test verify error for all script types.
+    for (ScriptService.ScriptType t : ScriptService.ScriptType.values()) {
+      conf.scriptType = t;
+      ElasticSearchTarget target = new ElasticSearchTarget(conf);
+      TargetRunner runner = new TargetRunner.Builder(ElasticSearchDTarget.class, target).build();
+      List<Stage.ConfigIssue> issues = runner.runValidateConfigs();
+      Assert.assertEquals(1, issues.size());
+      Assert.assertTrue(issues.get(0).toString().contains(Errors.ELASTICSEARCH_30.name()));
+      Assert.assertTrue(issues.get(0).toString().contains("es.script." + t.toString().toLowerCase()));
+    }
+  }
+
+  @Test
+  public void testScriptedUpsertInline() throws Exception {
+    esServer.close();
+
+    File esDir = new File("target", UUID.randomUUID().toString());
+    Map<String, Object> configs = new HashMap<>();
+    configs.put("cluster.name", esName);
+    configs.put("http.enabled", true);
+    configs.put("http.port", esHttpPort);
+    configs.put("transport.tcp.port", esPort);
+    configs.put("path.home", esDir.getAbsolutePath());
+    configs.put("path.conf", esDir.getAbsolutePath());
+    configs.put("path.data", esDir.getAbsolutePath());
+    configs.put("path.logs", esDir.getAbsolutePath());
+    configs.put("script.update", true);
+    configs.put("script.inline", true);
+    configs.put("script.file", true);
+    configs.put("script.indexed", true);
+
+    esServer = NodeBuilder.nodeBuilder().settings(ElasticSearchFactory.settings(configs)).build();
+    esServer.start();
+
+    ElasticSearchConfigBean conf = new ElasticSearchConfigBean();
+    conf.clusterName = esName;
+    conf.uris = ImmutableList.of("127.0.0.1:" + esPort);
+    conf.httpUri = "127.0.0.1:" + esHttpPort;
+    conf.configs = Collections.EMPTY_MAP;
+    conf.timeDriver = "${time:now()}";
+    conf.timeZoneID = "UTC";
+    conf.indexTemplate = "${record:value('/index')}";
+    conf.typeTemplate = "${record:value('/type')}";
+    conf.docIdTemplate = "${record:value('/docid')}";
+    conf.charset = "UTF-8";
+    conf.upsert = true;
+    conf.useShield = false;
+    conf.shieldConfigBean = new ShieldConfigBean();
+    conf.upsertScript = "ctx._source.counter += count"; // inline script
+    conf.scriptType = ScriptService.ScriptType.INLINE;
+    conf.scriptLanguage = "groovy";
+    conf.scriptParams = new HashMap<>();
+    conf.scriptParams.put("count", "${2}");
+
+    ElasticSearchTarget target = new ElasticSearchTarget(conf);
+    TargetRunner runner = new TargetRunner.Builder(ElasticSearchDTarget.class, target).build();
+    List<Stage.ConfigIssue> issues = runner.runValidateConfigs();
+    Assert.assertEquals(0, issues.size());
+
+    try {
+      runner.runInit();
+      List<Record> records = new ArrayList<>();
+      Record record = RecordCreator.create();
+      record.set(
+          Field.create(
+              ImmutableMap.of(
+                  "docid", Field.create("doc1"),
+                  "index", Field.create("j"),
+                  "counter", Field.create(0),
+                  "type", Field.create("t")
+              )
+          )
+      );
+
+      records.add(record);
+      runner.runWrite(records);
+      Assert.assertTrue(runner.getErrorRecords().isEmpty());
+      Assert.assertTrue(runner.getErrors().isEmpty());
+
+      prepareElasticSearchServerForQueries();
+
+      // Record count field should increment by 2.
+      Set<Map> expected = new HashSet<>();
+      expected.add(ImmutableMap.of("counter", 2, "index", "j", "type", "t"));
+
+      SearchResponse response = esServer.client().prepareSearch("j").setTypes("t")
+              .setSearchType(SearchType.DEFAULT).execute().actionGet();
+      SearchHit[] hits = response.getHits().getHits();
+      Assert.assertEquals(1, hits.length);
+      Set<Map> got = new HashSet<>();
+      got.add(hits[0].getSource());
+
+      Assert.assertEquals(expected, got);
+
+    } finally {
+      runner.runDestroy();
+    }
+
+  }
 }


### PR DESCRIPTION
Hey guys,

One of my primary use cases for StreamSets is streaming timeseries rollups. To do this with ElasticSearch I'm using the scripted upsert feature where records are aggregated server-side at time of insert/update using a groovy script. 

I didn't see a way to do this with the current version of StreamSets and went ahead and implemented it. Hopefully you guys find this contribution useful. I forked it from the 1.3 branch because that's what I'm using in production.

Some of the things that are still **not** implemented:

- [x] More validation of the ES server config/version checks, when specifying the various script types, you can get this from the ES API to check if the config has scripting enabled. Also, the Indexed scripts are a new feature as of ES 2.x.
- [x] Update the user documentation.
- [x] Unit tests.

Screenshot of ElasticSearch destination "Scripted Upsert" group config (enabled when `upsert` is checked):
![scriptedupsert](https://cloud.githubusercontent.com/assets/323725/15159474/c90ba268-16a9-11e6-8da8-6bb8b95a9170.png)

UPDATE: I'm closing this PR in favor of another one that merges into master.
