### PR TITLE
Implements features to allow Elasticsearch documents to be indexed into a parent/child structure

### DIFF
--- a/elasticsearch-protolib/src/main/java/com/streamsets/pipeline/stage/config/elasticsearch/ElasticsearchTargetConfig.java
+++ b/elasticsearch-protolib/src/main/java/com/streamsets/pipeline/stage/config/elasticsearch/ElasticsearchTargetConfig.java
@@ -110,6 +110,18 @@ public class ElasticsearchTargetConfig extends ElasticsearchConfig {
   public String parentIdTemplate;
 
   @ConfigDef(
+          required = false,
+          type = ConfigDef.Type.STRING,
+          label = "Routing",
+          description = "An expression which evaluates to a document ID whose shard will be indexed on.",
+          displayPosition = 87,
+          group = "ELASTIC_SEARCH",
+          elDefs = {RecordEL.class, DataUtilEL.class},
+          evaluation = ConfigDef.Evaluation.EXPLICIT
+  )
+  public String routingTemplate;
+
+  @ConfigDef(
       required = true,
       type = ConfigDef.Type.MODEL,
       defaultValue = "UTF-8",

--- a/elasticsearch-protolib/src/main/java/com/streamsets/pipeline/stage/config/elasticsearch/ElasticsearchTargetConfig.java
+++ b/elasticsearch-protolib/src/main/java/com/streamsets/pipeline/stage/config/elasticsearch/ElasticsearchTargetConfig.java
@@ -98,6 +98,18 @@ public class ElasticsearchTargetConfig extends ElasticsearchConfig {
   public String docIdTemplate;
 
   @ConfigDef(
+          required = false,
+          type = ConfigDef.Type.STRING,
+          label = "Parent ID",
+          description = "An expression which evaluates to a document ID for the parent in a parent/child hierarchy.",
+          displayPosition = 85,
+          group = "ELASTIC_SEARCH",
+          elDefs = {RecordEL.class, DataUtilEL.class},
+          evaluation = ConfigDef.Evaluation.EXPLICIT
+  )
+  public String parentIdTemplate;
+
+  @ConfigDef(
       required = true,
       type = ConfigDef.Type.MODEL,
       defaultValue = "UTF-8",

--- a/elasticsearch-protolib/src/main/java/com/streamsets/pipeline/stage/config/elasticsearch/Errors.java
+++ b/elasticsearch-protolib/src/main/java/com/streamsets/pipeline/stage/config/elasticsearch/Errors.java
@@ -45,13 +45,14 @@ public enum Errors implements ErrorCode {
   ELASTICSEARCH_18("Could not evaluate the time driver expression: {}"),
   ELASTICSEARCH_19("Document ID expression must be provided to use {} operation"),
   ELASTICSEARCH_20("Invalid Security user, it must be <USERNAME>:<PASSWORD>: '{}'"),
-  // Origin
   ELASTICSEARCH_21("Could not find _scroll_id field in response to query."),
   ELASTICSEARCH_22("Failed to fetch batch: '{}'"),
   ELASTICSEARCH_23("Cursor expired, please Reset Origin and restart the pipeline."),
   ELASTICSEARCH_24("Offset field '{}' not found in parsed record."),
   ELASTICSEARCH_25("Incremental mode requires the query to contain ${OFFSET} in at least one field"),
   ELASTICSEARCH_26("Changing the parallelism from '{}' to '{}' slices requires resetting the origin as it recomputes shards."),
+  ELASTICSEARCH_27("Could not parse the parent ID template expression: {}"),
+  ELASTICSEARCH_28("Could not evaluate the parent ID template expression: {}"),
   ;
   private final String msg;
 

--- a/elasticsearch-protolib/src/main/java/com/streamsets/pipeline/stage/config/elasticsearch/Errors.java
+++ b/elasticsearch-protolib/src/main/java/com/streamsets/pipeline/stage/config/elasticsearch/Errors.java
@@ -53,6 +53,8 @@ public enum Errors implements ErrorCode {
   ELASTICSEARCH_26("Changing the parallelism from '{}' to '{}' slices requires resetting the origin as it recomputes shards."),
   ELASTICSEARCH_27("Could not parse the parent ID template expression: {}"),
   ELASTICSEARCH_28("Could not evaluate the parent ID template expression: {}"),
+  ELASTICSEARCH_29("Could not parse the routing template expression: {}"),
+  ELASTICSEARCH_30("Could not evaluate the routing template expression: {}"),
   ;
   private final String msg;
 

--- a/elasticsearch-protolib/src/main/java/com/streamsets/pipeline/stage/config/elasticsearch/Errors.java
+++ b/elasticsearch-protolib/src/main/java/com/streamsets/pipeline/stage/config/elasticsearch/Errors.java
@@ -45,6 +45,7 @@ public enum Errors implements ErrorCode {
   ELASTICSEARCH_18("Could not evaluate the time driver expression: {}"),
   ELASTICSEARCH_19("Document ID expression must be provided to use {} operation"),
   ELASTICSEARCH_20("Invalid Security user, it must be <USERNAME>:<PASSWORD>: '{}'"),
+  // Origin
   ELASTICSEARCH_21("Could not find _scroll_id field in response to query."),
   ELASTICSEARCH_22("Failed to fetch batch: '{}'"),
   ELASTICSEARCH_23("Cursor expired, please Reset Origin and restart the pipeline."),

--- a/elasticsearch-protolib/src/main/java/com/streamsets/pipeline/stage/destination/elasticsearch/ElasticsearchTarget.java
+++ b/elasticsearch-protolib/src/main/java/com/streamsets/pipeline/stage/destination/elasticsearch/ElasticsearchTarget.java
@@ -392,7 +392,6 @@ public class ElasticsearchTarget extends BaseTarget {
 
   private void getOperationMetadata(String operation, String index, String type, String id, String parent, String routing, StringBuilder sb) {
     sb.append(String.format("{\"%s\":{\"_index\":\"%s\",\"_type\":\"%s\"", operation, index, type));
-
     if (!StringUtils.isEmpty(id)) {
       sb.append(String.format(",\"_id\":\"%s\"", id));
     }
@@ -402,7 +401,7 @@ public class ElasticsearchTarget extends BaseTarget {
     if (!StringUtils.isEmpty(routing)) {
       sb.append(String.format(",\"routing\":\"%s\"", routing));
     }
-    sb.append("}}%n");
+    sb.append(String.format("}}%n"));
   }
 
   private List<ErrorItem> extractErrorItems(JsonObject json) {

--- a/elasticsearch-protolib/src/main/java/com/streamsets/pipeline/stage/destination/elasticsearch/ElasticsearchTarget.java
+++ b/elasticsearch-protolib/src/main/java/com/streamsets/pipeline/stage/destination/elasticsearch/ElasticsearchTarget.java
@@ -79,6 +79,7 @@ public class ElasticsearchTarget extends BaseTarget {
   private ELEval indexEval;
   private ELEval typeEval;
   private ELEval docIdEval;
+  private ELEval parentIdEval;
   private DataGeneratorFactory generatorFactory;
   private ErrorRecordHandler errorRecordHandler;
   private ElasticsearchStageDelegate delegate;
@@ -117,6 +118,7 @@ public class ElasticsearchTarget extends BaseTarget {
     indexEval = getContext().createELEval("indexTemplate");
     typeEval = getContext().createELEval("typeTemplate");
     docIdEval = getContext().createELEval("docIdTemplate");
+    parentIdEval = getContext().createELEval("parentIdTemplate");
     timeDriverEval = getContext().createELEval("timeDriver");
 
     try {
@@ -167,6 +169,16 @@ public class ElasticsearchTarget extends BaseTarget {
             )
         );
       }
+    }
+    if (!StringUtils.isEmpty(conf.parentIdTemplate)) {
+      validateEL(
+              typeEval,
+              conf.parentIdTemplate,
+              "elasticSearchConfig.docIdTemplate",
+              Errors.ELASTICSEARCH_04,
+              Errors.ELASTICSEARCH_05,
+              issues
+      );
     }
 
     delegate = new ElasticsearchStageDelegate(getContext(), conf);
@@ -230,8 +242,12 @@ public class ElasticsearchTarget extends BaseTarget {
         String index = getRecordIndex(elVars, record);
         String type = typeEval.eval(elVars, conf.typeTemplate, String.class);
         String id = null;
+        String parentId = null;
         if (!StringUtils.isEmpty(conf.docIdTemplate)) {
           id = docIdEval.eval(elVars, conf.docIdTemplate, String.class);
+        }
+        if (!StringUtils.isEmpty(conf.parentIdTemplate)) {
+          parentId = docIdEval.eval(elVars, conf.parentIdTemplate, String.class);
         }
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         DataGenerator generator = generatorFactory.getGenerator(baos);

--- a/elasticsearch-protolib/src/main/java/com/streamsets/pipeline/stage/destination/elasticsearch/ElasticsearchTarget.java
+++ b/elasticsearch-protolib/src/main/java/com/streamsets/pipeline/stage/destination/elasticsearch/ElasticsearchTarget.java
@@ -80,6 +80,7 @@ public class ElasticsearchTarget extends BaseTarget {
   private ELEval typeEval;
   private ELEval docIdEval;
   private ELEval parentIdEval;
+  private ELEval routingEval;
   private DataGeneratorFactory generatorFactory;
   private ErrorRecordHandler errorRecordHandler;
   private ElasticsearchStageDelegate delegate;
@@ -119,6 +120,7 @@ public class ElasticsearchTarget extends BaseTarget {
     typeEval = getContext().createELEval("typeTemplate");
     docIdEval = getContext().createELEval("docIdTemplate");
     parentIdEval = getContext().createELEval("parentIdTemplate");
+    routingEval = getContext().createELEval("routingTemplate");
     timeDriverEval = getContext().createELEval("timeDriver");
 
     try {
@@ -177,6 +179,16 @@ public class ElasticsearchTarget extends BaseTarget {
               "elasticSearchConfig.parentIdTemplate",
               Errors.ELASTICSEARCH_27,
               Errors.ELASTICSEARCH_28,
+              issues
+      );
+    }
+    if (!StringUtils.isEmpty(conf.routingTemplate)) {
+      validateEL(
+              typeEval,
+              conf.routingTemplate,
+              "elasticSearchConfig.routingTemplate",
+              Errors.ELASTICSEARCH_29,
+              Errors.ELASTICSEARCH_30,
               issues
       );
     }
@@ -249,6 +261,10 @@ public class ElasticsearchTarget extends BaseTarget {
         if (!StringUtils.isEmpty(conf.parentIdTemplate)) {
           parent = parentIdEval.eval(elVars, conf.parentIdTemplate, String.class);
         }
+        String routing = null;
+        if (!StringUtils.isEmpty(conf.routingTemplate)) {
+          routing = routingEval.eval(elVars, conf.routingTemplate, String.class);
+        }
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         DataGenerator generator = generatorFactory.getGenerator(baos);
         generator.write(record);
@@ -281,7 +297,7 @@ public class ElasticsearchTarget extends BaseTarget {
           // No header attribute set. Use default.
           opCode = conf.defaultOperation.code;
         }
-        bulkRequest.append(getOperation(index, type, id, parent, recordJson, opCode));
+        bulkRequest.append(getOperation(index, type, id, parent, routing, recordJson, opCode));
       } catch (IOException ex) {
         errorRecordHandler.onError(
             new OnRecordErrorException(
@@ -349,23 +365,23 @@ public class ElasticsearchTarget extends BaseTarget {
     return batchTime;
   }
 
-  private String getOperation(String index, String type, String id, String parent, String record, int opCode) {
+  private String getOperation(String index, String type, String id, String parent, String routing, String record, int opCode) {
     StringBuilder op = new StringBuilder();
     switch (opCode) {
       case OperationType.UPSERT_CODE:
-        op.append(String.format("{\"index\":%s}%n", getOperationMetadata(index, type, id, parent)));
+        getOperationMetadata("index", index, type, id, parent, routing, op);
         op.append(String.format("%s%n", record));
         break;
       case OperationType.INSERT_CODE:
-        op.append(String.format("{\"create\":%s}%n", getOperationMetadata(index, type, id, parent)));
+        getOperationMetadata("create", index, type, id, parent, routing, op);
         op.append(String.format("%s%n", record));
         break;
       case OperationType.UPDATE_CODE:
-        op.append(String.format("{\"update\":%s}%n", getOperationMetadata(index, type, id, parent)));
+        getOperationMetadata("update", index, type, id, parent, routing, op);
         op.append(String.format("{\"doc\":%s}%n", record));
         break;
       case OperationType.DELETE_CODE:
-        op.append(String.format("{\"delete\":%s}%n", getOperationMetadata(index, type, id, parent)));
+        getOperationMetadata("delete", index, type, id, parent, routing, op);
         break;
       default:
         LOG.error("Operation {} not supported", opCode);
@@ -374,18 +390,19 @@ public class ElasticsearchTarget extends BaseTarget {
     return op.toString();
   }
 
-  private String getOperationMetadata(String index, String type, String id, String parent) {
-    String indexOp = String.format("{\"_index\":\"%s\",\"_type\":\"%s\"", index, type);
-    
+  private void getOperationMetadata(String operation, String index, String type, String id, String parent, String routing, StringBuilder sb) {
+    sb.append(String.format("{\"%s\":{\"_index\":\"%s\",\"_type\":\"%s\"", operation, index, type));
+
     if (!StringUtils.isEmpty(id)) {
-      indexOp += String.format(",\"_id\":\"%s\"", id);
+      sb.append(String.format(",\"_id\":\"%s\"", id));
     }
     if (!StringUtils.isEmpty(parent)) {
-      indexOp += String.format(",\"parent\":\"%s\"", parent);
+      sb.append(String.format(",\"parent\":\"%s\"", parent));
     }
-    indexOp += "}";
-
-    return indexOp;
+    if (!StringUtils.isEmpty(routing)) {
+      sb.append(String.format(",\"routing\":\"%s\"", routing));
+    }
+    sb.append("}}%n");
   }
 
   private List<ErrorItem> extractErrorItems(JsonObject json) {

--- a/elasticsearch-protolib/src/main/java/com/streamsets/pipeline/stage/destination/elasticsearch/ElasticsearchTarget.java
+++ b/elasticsearch-protolib/src/main/java/com/streamsets/pipeline/stage/destination/elasticsearch/ElasticsearchTarget.java
@@ -375,18 +375,17 @@ public class ElasticsearchTarget extends BaseTarget {
   }
 
   private String getOperationMetadata(String index, String type, String id, String parent) {
-    StringBuilder indexOp = new StringBuilder();
-
-    indexOp.append(String.format("{\"_index\":\"%s\",\"_type\":\"%s\"", index, type));
+    String indexOp = String.format("{\"_index\":\"%s\",\"_type\":\"%s\"", index, type);
+    
     if (!StringUtils.isEmpty(id)) {
-      indexOp.append(String.format(",\"_id\":\"%s\"", id));
+      indexOp += String.format(",\"_id\":\"%s\"", id);
     }
     if (!StringUtils.isEmpty(parent)) {
-      indexOp.append(String.format(",\"parent\":\"%s\"", parent));
+      indexOp += String.format(",\"parent\":\"%s\"", parent);
     }
-    indexOp.append("}");
+    indexOp += "}";
 
-    return indexOp.toString();
+    return indexOp;
   }
 
   private List<ErrorItem> extractErrorItems(JsonObject json) {

--- a/elasticsearch-protolib/src/main/java/com/streamsets/pipeline/stage/destination/elasticsearch/ElasticsearchTarget.java
+++ b/elasticsearch-protolib/src/main/java/com/streamsets/pipeline/stage/destination/elasticsearch/ElasticsearchTarget.java
@@ -174,9 +174,9 @@ public class ElasticsearchTarget extends BaseTarget {
       validateEL(
               typeEval,
               conf.parentIdTemplate,
-              "elasticSearchConfig.docIdTemplate",
-              Errors.ELASTICSEARCH_04,
-              Errors.ELASTICSEARCH_05,
+              "elasticSearchConfig.parentIdTemplate",
+              Errors.ELASTICSEARCH_27,
+              Errors.ELASTICSEARCH_28,
               issues
       );
     }
@@ -242,12 +242,12 @@ public class ElasticsearchTarget extends BaseTarget {
         String index = getRecordIndex(elVars, record);
         String type = typeEval.eval(elVars, conf.typeTemplate, String.class);
         String id = null;
-        String parentId = null;
         if (!StringUtils.isEmpty(conf.docIdTemplate)) {
           id = docIdEval.eval(elVars, conf.docIdTemplate, String.class);
         }
+        String parent = null;
         if (!StringUtils.isEmpty(conf.parentIdTemplate)) {
-          parentId = docIdEval.eval(elVars, conf.parentIdTemplate, String.class);
+          parent = parentIdEval.eval(elVars, conf.parentIdTemplate, String.class);
         }
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         DataGenerator generator = generatorFactory.getGenerator(baos);
@@ -281,7 +281,7 @@ public class ElasticsearchTarget extends BaseTarget {
           // No header attribute set. Use default.
           opCode = conf.defaultOperation.code;
         }
-        bulkRequest.append(getOperation(index, type, id, recordJson, opCode));
+        bulkRequest.append(getOperation(index, type, id, parent, recordJson, opCode));
       } catch (IOException ex) {
         errorRecordHandler.onError(
             new OnRecordErrorException(
@@ -349,33 +349,44 @@ public class ElasticsearchTarget extends BaseTarget {
     return batchTime;
   }
 
-  private String getOperation(String index, String type, String id, String record, int opCode) {
+  private String getOperation(String index, String type, String id, String parent, String record, int opCode) {
     StringBuilder op = new StringBuilder();
     switch (opCode) {
       case OperationType.UPSERT_CODE:
-        if (StringUtils.isEmpty(id)) {
-          op.append(String.format("{\"index\":{\"_index\":\"%s\",\"_type\":\"%s\"}}%n", index, type));
-        } else {
-          op.append(String.format("{\"index\":{\"_index\":\"%s\",\"_type\":\"%s\",\"_id\":\"%s\"}}%n", index, type, id));
-        }
+        op.append(String.format("{\"index\":%s}%n", getOperationMetadata(index, type, id, parent)));
         op.append(String.format("%s%n", record));
         break;
       case OperationType.INSERT_CODE:
-        op.append(String.format("{\"create\":{\"_index\":\"%s\",\"_type\":\"%s\",\"_id\":\"%s\"}}%n", index, type, id));
+        op.append(String.format("{\"create\":%s}%n", getOperationMetadata(index, type, id, parent)));
         op.append(String.format("%s%n", record));
         break;
       case OperationType.UPDATE_CODE:
-        op.append(String.format("{\"update\":{\"_index\":\"%s\",\"_type\":\"%s\",\"_id\":\"%s\"}}%n", index, type, id));
+        op.append(String.format("{\"update\":%s}%n", getOperationMetadata(index, type, id, parent)));
         op.append(String.format("{\"doc\":%s}%n", record));
         break;
       case OperationType.DELETE_CODE:
-        op.append(String.format("{\"delete\":{\"_index\":\"%s\",\"_type\":\"%s\",\"_id\":\"%s\"}}%n", index, type, id));
+        op.append(String.format("{\"delete\":%s}%n", getOperationMetadata(index, type, id, parent)));
         break;
       default:
         LOG.error("Operation {} not supported", opCode);
         throw new UnsupportedOperationException(String.format("Unsupported Operation: %s", opCode));
     }
     return op.toString();
+  }
+
+  private String getOperationMetadata(String index, String type, String id, String parent) {
+    StringBuilder indexOp = new StringBuilder();
+
+    indexOp.append(String.format("{\"_index\":\"%s\",\"_type\":\"%s\"", index, type));
+    if (!StringUtils.isEmpty(id)) {
+      indexOp.append(String.format(",\"_id\":\"%s\"", id));
+    }
+    if (!StringUtils.isEmpty(parent)) {
+      indexOp.append(String.format(",\"parent\":\"%s\"", parent));
+    }
+    indexOp.append("}");
+
+    return indexOp.toString();
   }
 
   private List<ErrorItem> extractErrorItems(JsonObject json) {

--- a/elasticsearch-protolib/src/test/java/com/streamsets/pipeline/stage/destination/elasticsearch/ElasticSearchTargetIT.java
+++ b/elasticsearch-protolib/src/test/java/com/streamsets/pipeline/stage/destination/elasticsearch/ElasticSearchTargetIT.java
@@ -30,7 +30,6 @@ import com.streamsets.pipeline.api.el.ELVars;
 import com.streamsets.pipeline.lib.el.RecordEL;
 import com.streamsets.pipeline.sdk.RecordCreator;
 import com.streamsets.pipeline.sdk.TargetRunner;
-import com.streamsets.pipeline.stage.config.elasticsearch.ElasticsearchConfig;
 import com.streamsets.pipeline.stage.config.elasticsearch.ElasticsearchTargetConfig;
 import com.streamsets.pipeline.stage.config.elasticsearch.Errors;
 import com.streamsets.pipeline.stage.config.elasticsearch.SecurityConfig;
@@ -147,8 +146,8 @@ public class ElasticSearchTargetIT extends ElasticsearchBaseIT {
     runner = new TargetRunner.Builder(ElasticSearchDTarget.class, target).build();
     issues = runner.runValidateConfigs();
     Assert.assertEquals(2, issues.size());
-    Assert.assertTrue(issues.get(0).toString().contains(Errors.ELASTICSEARCH_21.name()));
-    Assert.assertTrue(issues.get(1).toString().contains(Errors.ELASTICSEARCH_24.name()));
+    Assert.assertTrue(issues.get(0).toString().contains(Errors.ELASTICSEARCH_27.name()));
+    Assert.assertTrue(issues.get(1).toString().contains(Errors.ELASTICSEARCH_30.name()));
   }
 
   private Target createTarget() {
@@ -168,7 +167,7 @@ public class ElasticSearchTargetIT extends ElasticsearchBaseIT {
   private ElasticsearchTarget createTarget(String timeDriver, String indexEL, String docIdEL, ElasticsearchOperationType op,
                                            String parent, String routing) {
     ElasticsearchTargetConfig conf = new ElasticsearchTargetConfig();
-    conf.httpUris = Arrays.asList("127.0.0.1:" + esHttpPort);
+    conf.httpUris = Collections.singletonList("127.0.0.1:" + esHttpPort);
     conf.timeDriver = timeDriver;
     conf.timeZoneID = "UTC";
     conf.indexTemplate = indexEL;


### PR DESCRIPTION
Adds parentID and routingID to Elasticsearch destination.  (See issue https://issues.streamsets.com/browse/SDC-5244)