### PR TITLE
SDC-6441 Add rolesWithExternalLinks to CM CSD service descriptor

### DIFF
--- a/cloudera-integration/csd/src/main/descriptor/service.sdl
+++ b/cloudera-integration/csd/src/main/descriptor/service.sdl
@@ -38,6 +38,7 @@
       "runMode" : "all"
     }
   ],
+  "rolesWithExternalLinks" : ["DATACOLLECTOR"],
   "roles": [
     {
       "name": "DATACOLLECTOR",


### PR DESCRIPTION
Add rolesWithExternalLinks to CM CSD service descriptor. This will promote the SDC WebUI links to the service level so you don't have to navigate down to the data collector instance to find the web ui link.