### PR TITLE
Kudu Lookup Processor

### DIFF
--- a/kudu-protolib/pom.xml
+++ b/kudu-protolib/pom.xml
@@ -76,6 +76,13 @@
     </dependency>
 
     <dependency>
+      <groupId>com.streamsets</groupId>
+      <artifactId>streamsets-datacollector-lookup-protolib</artifactId>
+      <version>${project.version}</version>
+      <scope>compile</scope>
+    </dependency>
+
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/kudu-protolib/src/main/java/com/streamsets/pipeline/stage/destination/kudu/Errors.java
+++ b/kudu-protolib/src/main/java/com/streamsets/pipeline/stage/destination/kudu/Errors.java
@@ -42,7 +42,8 @@ public enum Errors implements ErrorCode {
 
   KUDU_30("Column mappings must be specified for lookup processor"),
   KUDU_31("No rows found"),
-  KUDU_32("Primary key field '{}' not found in record")
+  KUDU_32("Primary key field '{}' not found in record"),
+  KUDU_33("Unsupported primary key type: {}")
   ;
   private final String msg;
 

--- a/kudu-protolib/src/main/java/com/streamsets/pipeline/stage/destination/kudu/Errors.java
+++ b/kudu-protolib/src/main/java/com/streamsets/pipeline/stage/destination/kudu/Errors.java
@@ -27,7 +27,7 @@ public enum Errors implements ErrorCode {
   KUDU_00("Error connecting to kudu master '{}': {}"),
   KUDU_01("Table '{}' does not exist"),
   KUDU_02("Parameter is not valid"),
-  KUDU_03("Errors while writing to Kudu: {}"),
+  KUDU_03("Errors while interacting with Kudu: {}"),
   KUDU_04("Column or field '{}' is not type '{}'"),
   KUDU_05("Column '{}' does not exist"),
   KUDU_06("Column '{}' mapped from field '{}' is not nullable"),
@@ -38,7 +38,11 @@ public enum Errors implements ErrorCode {
   KUDU_12("Invalid table name template expression '{}': {}"),
   KUDU_13("Operation not supported: {}"),
   KUDU_14("Unknown action for unsupported operation: {}"),
-  KUDU_15("Row key {} not found")
+  KUDU_15("Row key {} not found"),
+
+  KUDU_30("Column mappings must be specified for lookup processor"),
+  KUDU_31("No rows found"),
+  KUDU_32("Primary key field '{}' not found in record")
   ;
   private final String msg;
 

--- a/kudu-protolib/src/main/java/com/streamsets/pipeline/stage/processor/kudulookup/KuduLookupConfig.java
+++ b/kudu-protolib/src/main/java/com/streamsets/pipeline/stage/processor/kudulookup/KuduLookupConfig.java
@@ -58,7 +58,7 @@ public class KuduLookupConfig {
       type = ConfigDef.Type.MODEL,
       defaultValue = "",
       label = "Field to Column Mapping",
-      description = "Optionally specify additional field mappings when input field name and column name don't match.",
+      description = "Specify which columns from kudu to populate the record with",
       displayPosition = 40,
       group = "KUDU"
   )

--- a/kudu-protolib/src/main/java/com/streamsets/pipeline/stage/processor/kudulookup/KuduLookupConfig.java
+++ b/kudu-protolib/src/main/java/com/streamsets/pipeline/stage/processor/kudulookup/KuduLookupConfig.java
@@ -1,0 +1,93 @@
+/**
+ * Copyright 2016 StreamSets Inc.
+ *
+ * Licensed under the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.streamsets.pipeline.stage.processor.kudulookup;
+
+import com.streamsets.pipeline.api.ConfigDef;
+import com.streamsets.pipeline.api.ConfigDefBean;
+import com.streamsets.pipeline.api.ListBeanModel;
+import com.streamsets.pipeline.api.ValueChooserModel;
+import com.streamsets.pipeline.stage.common.MultipleValuesBehavior;
+import com.streamsets.pipeline.stage.destination.kudu.KuduFieldMappingConfig;
+import com.streamsets.pipeline.stage.processor.kv.CacheConfig;
+
+import java.util.List;
+
+public class KuduLookupConfig {
+  public static final String CONF_PREFIX = "kuduLookupConfig.";
+
+  // kudu tab
+  @ConfigDef(
+      required = true,
+      type = ConfigDef.Type.STRING,
+      label = "Kudu Masters",
+      description = "Comma-separated list of \"host:port\" pairs of the masters",
+      displayPosition = 10,
+      group = "KUDU"
+  )
+  public String kuduMaster;
+
+  // kudu tab
+  @ConfigDef(
+      required = true,
+      type = ConfigDef.Type.STRING,
+      label = "Kudu Table",
+      description = "Table name, case sensitive",
+      displayPosition = 20,
+      group = "KUDU"
+  )
+  public String kuduTable;
+
+  @ConfigDef(required = true,
+      type = ConfigDef.Type.MODEL,
+      defaultValue = "",
+      label = "Field to Column Mapping",
+      description = "Optionally specify additional field mappings when input field name and column name don't match.",
+      displayPosition = 40,
+      group = "KUDU"
+  )
+  @ListBeanModel
+  public List<KuduFieldMappingConfig> fieldMappingConfigs;
+
+  @ConfigDef(
+      required = true,
+      type = ConfigDef.Type.MODEL,
+      label = "Multiple Values Behavior",
+      description = "How to handle multiple values ",
+      defaultValue = "FIRST_ONLY",
+      displayPosition = 10,
+      group = "ADVANCED"
+  )
+  @ValueChooserModel(KuduLookupMultipleValuesBehaviorChooserValues.class)
+  public MultipleValuesBehavior multipleValuesBehavior = MultipleValuesBehavior.DEFAULT;
+
+  @ConfigDef(
+      required = true,
+      type = ConfigDef.Type.NUMBER,
+      defaultValue = "10000",
+      label = "Operation Timeout Milliseconds",
+      description = "Sets the default timeout used for user operations (using sessions and scanners)",
+      displayPosition = 30,
+      group = "ADVANCED"
+  )
+  public int operationTimeout;
+
+  @ConfigDefBean(groups = "LOOKUP")
+  public CacheConfig cache = new CacheConfig();
+}

--- a/kudu-protolib/src/main/java/com/streamsets/pipeline/stage/processor/kudulookup/KuduLookupDProcessor.java
+++ b/kudu-protolib/src/main/java/com/streamsets/pipeline/stage/processor/kudulookup/KuduLookupDProcessor.java
@@ -17,25 +17,30 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package com.streamsets.pipeline.stage.processor.kudulookup;
 
-package com.streamsets.pipeline.stage.destination.kudu;
+import com.streamsets.pipeline.api.*;
+import com.streamsets.pipeline.configurablestage.DProcessor;
+import com.streamsets.pipeline.stage.destination.kudu.Groups;
 
-import com.streamsets.pipeline.api.GenerateResourceBundle;
-import com.streamsets.pipeline.api.Label;
+@StageDef(
+    version = 1,
+    label = "Kudu Lookup",
+    description = "Performs KV lookups to enrich records",
+    icon = "kudu.png",
+    privateClassLoader = true,
+    upgrader = KuduProcessorUpgrader.class,
+    onlineHelpRefUrl = "TODO"
+)
 
+@ConfigGroups(Groups.class)
 @GenerateResourceBundle
-public enum Groups implements Label {
-  KUDU("Kudu"),
-  ADVANCED("Advanced"),
-  LOOKUP("Lookup");
-  private final String label;
-
-  Groups(String label) {
-    this.label = label;
-  }
+public class KuduLookupDProcessor extends DProcessor {
+  @ConfigDefBean(groups = {"LOOKUP", "KUDU"})
+  public KuduLookupConfig conf;
 
   @Override
-  public String getLabel() {
-    return label;
+  protected Processor createProcessor() {
+    return new KuduLookupProcessor(conf);
   }
 }

--- a/kudu-protolib/src/main/java/com/streamsets/pipeline/stage/processor/kudulookup/KuduLookupLoader.java
+++ b/kudu-protolib/src/main/java/com/streamsets/pipeline/stage/processor/kudulookup/KuduLookupLoader.java
@@ -1,0 +1,166 @@
+/**
+ * Copyright 2016 StreamSets Inc.
+ *
+ * Licensed under the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.streamsets.pipeline.stage.processor.kudulookup;
+
+import com.codahale.metrics.*;
+import com.codahale.metrics.Timer;
+import com.google.common.cache.CacheLoader;
+import com.streamsets.pipeline.api.Field;
+import com.streamsets.pipeline.api.Record;
+import com.streamsets.pipeline.api.Stage;
+import com.streamsets.pipeline.api.StageException;
+import com.streamsets.pipeline.api.base.OnRecordErrorException;
+import com.streamsets.pipeline.stage.destination.kudu.Errors;
+import org.apache.kudu.ColumnSchema;
+import org.apache.kudu.Type;
+import org.apache.kudu.client.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.*;
+
+public class KuduLookupLoader extends CacheLoader<Record, List<Map<String, Field>>> {
+  private static final Logger LOG = LoggerFactory.getLogger(KuduLookupLoader.class);
+
+  private final KuduClient kuduClient;
+  private final KuduTable kuduTable;
+  private final Meter selectMeter;
+  private final Timer selectTimer;
+  private final List<String> projectColumns;
+  private final Map<String, String> columnToField;
+  private final Map<String, String> fieldToColumn;
+
+  public KuduLookupLoader(Stage.Context context,
+                          KuduClient kuduClient,
+                          KuduTable kuduTable,
+                          List<String> projectColumns,
+                          Map<String, String> columnToField,
+                          Map<String, String> fieldToColumn,
+                          KuduLookupConfig config) {
+    this.selectMeter = context.createMeter("Select Queries");
+    this.selectTimer = context.createTimer("Select Queries");
+    this.kuduClient = kuduClient;
+    this.kuduTable = kuduTable;
+    this.projectColumns = projectColumns;
+    this.columnToField = columnToField;
+    this.fieldToColumn = fieldToColumn;
+  }
+
+  @Override
+  public List<Map<String, Field>> load(Record record) throws Exception {
+    LOG.debug("Looking up values for:  {}", record);
+    List<Map<String, Field>> lookupItems = new ArrayList<>();
+    KuduScanner scanner = null;
+    Timer.Context t = selectTimer.time();
+    try {
+      KuduScanner.KuduScannerBuilder scannerBuilder = kuduClient.newScannerBuilder(kuduTable)
+          .setProjectedColumnNames(projectColumns);
+      for (ColumnSchema keySchema : kuduTable.getSchema().getPrimaryKeyColumns()) {
+        String predicateColumn = keySchema.getName();
+        ColumnSchema schema = kuduTable.getSchema().getColumn(predicateColumn);
+        Type type = schema.getType();
+        String fieldName = columnToField.get(predicateColumn);
+        if (type == Type.STRING) {
+          String value = record.get(fieldName).getValueAsString();
+          if (value == null) {
+            throw new OnRecordErrorException(record, Errors.KUDU_32, fieldName);
+          } else {
+            scannerBuilder.addPredicate(KuduPredicate.newComparisonPredicate(schema, KuduPredicate.ComparisonOp.EQUAL, value));
+          }
+        } else if (type == Type.INT8 || type == Type.INT16 || type == Type.INT32 || type == Type.INT64) {
+          Long value = record.get(fieldName).getValueAsLong();
+          if (value == null) {
+            throw new OnRecordErrorException(record, Errors.KUDU_32, fieldName);
+          } else {
+            scannerBuilder.addPredicate(KuduPredicate.newComparisonPredicate(schema, KuduPredicate.ComparisonOp.EQUAL, value));
+          }
+        }
+      }
+      scanner = scannerBuilder.build();
+      while (scanner.hasMoreRows()) {
+        RowResultIterator results = scanner.nextRows();
+        while (results.hasNext()) {
+          RowResult result = results.next();
+          if (LOG.isDebugEnabled()) {
+            LOG.debug("Found row: {}", result.toStringLongFormat());
+          }
+          LinkedHashMap<String, Field> fields = new LinkedHashMap<>(projectColumns.size());
+          for (String column : projectColumns) {
+            Type type = result.getColumnType(column);
+            Field field = null;
+            switch (type) {
+              case INT8:
+                field = Field.create(Field.Type.BYTE, result.getByte(column));
+                break;
+              case INT16:
+                field = Field.create(Field.Type.SHORT, result.getShort(column));
+                break;
+              case INT32:
+                field = Field.create(Field.Type.INTEGER, result.getInt(column));
+                break;
+              case INT64:
+                field = Field.create(Field.Type.LONG, result.getLong(column));
+                break;
+              case BINARY:
+                field = Field.create(Field.Type.BYTE_ARRAY, result.getBinary(column));
+                break;
+              case STRING:
+                field = Field.create(Field.Type.STRING, result.getString(column));
+                break;
+              case BOOL:
+                field = Field.create(Field.Type.BOOLEAN, result.getBoolean(column));
+                break;
+              case FLOAT:
+                field = Field.create(Field.Type.FLOAT, result.getFloat(column));
+                break;
+              case DOUBLE:
+                field = Field.create(Field.Type.DOUBLE, result.getDouble(column));
+                break;
+              default:
+                throw new StageException(Errors.KUDU_10, column, type.getName());
+            }
+            String fieldName;
+            if (columnToField.containsKey(column)) {
+              fieldName = columnToField.get(column);
+            } else {
+              fieldName = column;
+            }
+            fields.put(fieldName, field);
+          }
+          lookupItems.add(fields);
+        }
+      }
+    } catch (KuduException e) {
+      // Exception executing query
+      LOG.error(Errors.KUDU_03.getMessage(), e.toString(), e);
+      throw new StageException(Errors.KUDU_03, e.toString(), e);
+    } finally {
+      if (scanner != null) {
+        scanner.close();
+      }
+      // If the timer wasn't stopped due to exception yet, stop it now
+      if(t != null) {
+        t.stop();
+      }
+      selectMeter.mark();
+    }
+    return lookupItems;
+  }
+}

--- a/kudu-protolib/src/main/java/com/streamsets/pipeline/stage/processor/kudulookup/KuduLookupLoader.java
+++ b/kudu-protolib/src/main/java/com/streamsets/pipeline/stage/processor/kudulookup/KuduLookupLoader.java
@@ -91,6 +91,8 @@ public class KuduLookupLoader extends CacheLoader<Record, List<Map<String, Field
           } else {
             scannerBuilder.addPredicate(KuduPredicate.newComparisonPredicate(schema, KuduPredicate.ComparisonOp.EQUAL, value));
           }
+        } else {
+          throw new StageException(Errors.KUDU_33, type.getName());
         }
       }
       scanner = scannerBuilder.build();

--- a/kudu-protolib/src/main/java/com/streamsets/pipeline/stage/processor/kudulookup/KuduLookupMultipleValuesBehaviorChooserValues.java
+++ b/kudu-protolib/src/main/java/com/streamsets/pipeline/stage/processor/kudulookup/KuduLookupMultipleValuesBehaviorChooserValues.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016 StreamSets Inc.
+ * Copyright 2017 StreamSets Inc.
  *
  * Licensed under the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -9,7 +9,7 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,25 +17,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package com.streamsets.pipeline.stage.processor.kudulookup;
 
-package com.streamsets.pipeline.stage.destination.kudu;
+import com.streamsets.pipeline.api.base.BaseEnumChooserValues;
+import com.streamsets.pipeline.stage.common.MultipleValuesBehavior;
 
-import com.streamsets.pipeline.api.GenerateResourceBundle;
-import com.streamsets.pipeline.api.Label;
-
-@GenerateResourceBundle
-public enum Groups implements Label {
-  KUDU("Kudu"),
-  ADVANCED("Advanced"),
-  LOOKUP("Lookup");
-  private final String label;
-
-  Groups(String label) {
-    this.label = label;
-  }
-
-  @Override
-  public String getLabel() {
-    return label;
+public class KuduLookupMultipleValuesBehaviorChooserValues extends BaseEnumChooserValues<MultipleValuesBehavior> {
+  public KuduLookupMultipleValuesBehaviorChooserValues() {
+    super(MultipleValuesBehavior.FIRST_ONLY, MultipleValuesBehavior.SPLIT_INTO_MULTIPLE_RECORDS);
   }
 }

--- a/kudu-protolib/src/main/java/com/streamsets/pipeline/stage/processor/kudulookup/KuduLookupProcessor.java
+++ b/kudu-protolib/src/main/java/com/streamsets/pipeline/stage/processor/kudulookup/KuduLookupProcessor.java
@@ -1,0 +1,241 @@
+/**
+ * Copyright 2016 StreamSets Inc.
+ *
+ * Licensed under the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.streamsets.pipeline.stage.processor.kudulookup;
+
+import com.google.common.base.Throwables;
+import com.google.common.cache.LoadingCache;
+import com.streamsets.pipeline.api.Batch;
+import com.streamsets.pipeline.api.Field;
+import com.streamsets.pipeline.api.Record;
+import com.streamsets.pipeline.api.StageException;
+import com.streamsets.pipeline.api.base.OnRecordErrorException;
+import com.streamsets.pipeline.api.base.SingleLaneProcessor;
+import com.streamsets.pipeline.api.base.SingleLaneRecordProcessor;
+import com.streamsets.pipeline.lib.cache.CacheCleaner;
+import com.streamsets.pipeline.stage.common.DefaultErrorRecordHandler;
+import com.streamsets.pipeline.stage.common.ErrorRecordHandler;
+import com.streamsets.pipeline.stage.destination.kudu.Errors;
+import com.streamsets.pipeline.stage.destination.kudu.Groups;
+import com.streamsets.pipeline.stage.destination.kudu.KuduFieldMappingConfig;
+import com.streamsets.pipeline.stage.processor.kv.LookupUtils;
+import org.apache.kudu.client.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+
+public class KuduLookupProcessor extends SingleLaneRecordProcessor {
+  private static final String KUDU_MASTER = "kuduMaster";
+  private static final String KUDU_TABLE = "kuduTable";
+  private static final String FIELD_MAPPING_CONFIGS = "fieldMappingConfigs";
+
+  private static final Logger LOG = LoggerFactory.getLogger(KuduLookupProcessor.class);
+  private KuduLookupConfig conf;
+  private ErrorRecordHandler errorRecordHandler;
+  private KuduClient kuduClient;
+  private KuduSession kuduSession;
+  private KuduTable kuduTable;
+  private KuduLookupLoader store;
+  private final List<String> projectColumns = new ArrayList<>();
+  private final Map<String, String> columnToField = new HashMap<>();
+  private final Map<String, String> fieldToColumn = new HashMap<>();
+  private LoadingCache<Record, List<Map<String, Field>>> cache;
+  private CacheCleaner cacheCleaner;
+
+  public KuduLookupProcessor(KuduLookupConfig conf) {
+    this.conf = conf;
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  protected List<ConfigIssue> init() {
+    final List<ConfigIssue> issues = super.init();
+    errorRecordHandler = new DefaultErrorRecordHandler(getContext());
+
+    if (conf.fieldMappingConfigs.isEmpty()) {
+      issues.add(getContext().createConfigIssue(
+          Groups.KUDU.name(),
+          KuduLookupConfig.CONF_PREFIX + FIELD_MAPPING_CONFIGS,
+          Errors.KUDU_30
+      ));
+    }
+
+    for (KuduFieldMappingConfig fieldConfig : conf.fieldMappingConfigs) {
+      projectColumns.add(fieldConfig.columnName);
+      columnToField.put(fieldConfig.columnName, fieldConfig.field);
+      fieldToColumn.put(fieldConfig.field, fieldConfig.columnName);
+    }
+
+    kuduClient = new KuduClient.KuduClientBuilder(conf.kuduMaster).defaultOperationTimeoutMs(conf.operationTimeout)
+        .build();
+    if (issues.isEmpty()) {
+      kuduSession = kuduClient.newSession();
+    }
+
+    if (issues.isEmpty()) {
+      // Check if SDC can reach the Kudu Master
+      try {
+        kuduClient.getTablesList();
+      } catch (KuduException ex) {
+        issues.add(
+            getContext().createConfigIssue(
+                Groups.KUDU.name(),
+                KuduLookupConfig.CONF_PREFIX + KUDU_MASTER,
+                Errors.KUDU_00,
+                ex.toString(),
+                ex
+            )
+        );
+      }
+    }
+
+    if (issues.isEmpty()) {
+      try {
+        kuduTable = kuduClient.openTable(conf.kuduTable);
+      } catch (KuduException ex) {
+        issues.add(
+            getContext().createConfigIssue(
+                Groups.KUDU.name(),
+                KuduLookupConfig.CONF_PREFIX + KUDU_TABLE,
+                Errors.KUDU_01,
+                conf.kuduTable,
+                ex
+            )
+        );
+      }
+    }
+
+    if (issues.isEmpty()) {
+      store = new KuduLookupLoader(getContext(), kuduClient, kuduTable, projectColumns, columnToField, fieldToColumn,
+          conf);
+      cache = LookupUtils.buildCache(store, conf.cache);
+      cacheCleaner = new CacheCleaner(cache, "KuduLookupProcessor", 10 * 60 * 1000);
+    }
+    return issues;
+  }
+
+
+  @Override
+  public void destroy() {
+    super.destroy();
+    if (kuduSession != null) {
+      try {
+        List<OperationResponse> result = kuduSession.close();
+        if (result != null && !result.isEmpty()) {
+          String msg = "Unexpected operation responses from session close: " + result;
+          throw new RuntimeException(msg);
+        }
+      } catch (IOException  e) {
+        String msg = "Unexpected exception closing KuduSession: " + e;
+        LOG.error(msg, e);
+        throw new RuntimeException(e);
+      }
+    }
+    if (kuduClient != null) {
+      try {
+        kuduClient.close();
+      } catch (IOException  e) {
+        String msg = "Unexpected exception closing KuduClient: " + e;
+        LOG.error(msg, e);
+        throw new RuntimeException(e);
+      }
+    }
+  }
+
+  @Override
+  public void process(Batch batch, SingleLaneProcessor.SingleLaneBatchMaker batchMaker) throws StageException {
+    if (!batch.getRecords().hasNext()) {
+      // No records - take the opportunity to clean up the cache so that we don't hold on to memory indefinitely
+      cacheCleaner.periodicCleanUp();
+    }
+    super.process(batch, batchMaker);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  protected void process(Record record, SingleLaneProcessor.SingleLaneBatchMaker batchMaker) throws StageException {
+    try {
+      try {
+        List<Map<String, Field>> values = cache.get(record);
+        if (values.isEmpty()) {
+          // No results
+          errorRecordHandler.onError(new OnRecordErrorException(record, Errors.KUDU_31));
+        } else {
+          switch (conf.multipleValuesBehavior) {
+            case FIRST_ONLY:
+              setFieldsInRecord(record, values.get(0));
+              batchMaker.addRecord(record);
+              break;
+            case SPLIT_INTO_MULTIPLE_RECORDS:
+              for(Map<String, Field> lookupItem : values) {
+                Record newRecord = getContext().cloneRecord(record);
+                setFieldsInRecord(newRecord, lookupItem);
+                batchMaker.addRecord(newRecord);
+              }
+              break;
+            default:
+              throw new IllegalStateException("Unknown multiple value behavior: " + conf.multipleValuesBehavior);
+          }
+        }
+      } catch (ExecutionException e) {
+        Throwables.propagateIfPossible(e.getCause(), StageException.class);
+        Throwables.propagateIfPossible(e.getCause(), OnRecordErrorException.class);
+        throw new IllegalStateException(e); // The cache loader shouldn't throw anything that isn't a StageException.
+      }
+    } catch (OnRecordErrorException error) { // NOSONAR
+      errorRecordHandler.onError(new OnRecordErrorException(record, error.getErrorCode(), error.getParams()));
+    }
+  }
+
+  private void setFieldsInRecord(Record record, Map<String, Field>fields) {
+    for (Map.Entry<String, Field> entry : fields.entrySet()) {
+      String columnName = entry.getKey();
+      String fieldPath = columnToField.get(columnName);
+      Field field = entry.getValue();
+      if (fieldPath == null) {
+        Field root = record.get();
+        // No mapping
+        switch (root.getType()) {
+          case LIST:
+            // Add new field to the end of the list
+            fieldPath = "[" + root.getValueAsList().size() + "]";
+            Map<String, Field> cell = new HashMap<>();
+            cell.put("header", Field.create(columnName));
+            cell.put("value", field);
+            field = Field.create(cell);
+            break;
+          case LIST_MAP:
+          case MAP:
+            // Just use the column name
+            fieldPath = "/" + columnName;
+            break;
+          default:
+            break;
+        }
+      }
+      record.set(fieldPath, field);
+    }
+  }
+}

--- a/kudu-protolib/src/main/java/com/streamsets/pipeline/stage/processor/kudulookup/KuduProcessorUpgrader.java
+++ b/kudu-protolib/src/main/java/com/streamsets/pipeline/stage/processor/kudulookup/KuduProcessorUpgrader.java
@@ -9,7 +9,7 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -18,24 +18,20 @@
  * limitations under the License.
  */
 
-package com.streamsets.pipeline.stage.destination.kudu;
+package com.streamsets.pipeline.stage.processor.kudulookup;
 
-import com.streamsets.pipeline.api.GenerateResourceBundle;
-import com.streamsets.pipeline.api.Label;
+import com.streamsets.pipeline.api.Config;
+import com.streamsets.pipeline.api.StageException;
+import com.streamsets.pipeline.api.StageUpgrader;
 
-@GenerateResourceBundle
-public enum Groups implements Label {
-  KUDU("Kudu"),
-  ADVANCED("Advanced"),
-  LOOKUP("Lookup");
-  private final String label;
+import java.util.List;
 
-  Groups(String label) {
-    this.label = label;
-  }
+public class KuduProcessorUpgrader implements StageUpgrader {
 
   @Override
-  public String getLabel() {
-    return label;
+  public List<Config> upgrade(
+      String library, String stageName, String stageInstance, int fromVersion, int toVersion, List<Config> configs
+  ) throws StageException {
+    return configs;
   }
 }

--- a/kudu-protolib/src/test/java/com/streamsets/pipeline/stage/processor/kudulookup/TestKuduLookup.java
+++ b/kudu-protolib/src/test/java/com/streamsets/pipeline/stage/processor/kudulookup/TestKuduLookup.java
@@ -1,0 +1,181 @@
+/**
+ * Copyright 2016 StreamSets Inc.
+ *
+ * Licensed under the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.streamsets.pipeline.stage.processor.kudulookup;
+
+import com.google.common.collect.ImmutableList;
+import com.streamsets.pipeline.api.*;
+import com.streamsets.pipeline.lib.operation.OperationType;
+import com.streamsets.pipeline.lib.operation.UnsupportedOperationAction;
+import com.streamsets.pipeline.sdk.ProcessorRunner;
+import com.streamsets.pipeline.sdk.RecordCreator;
+import com.streamsets.pipeline.sdk.TargetRunner;
+import com.streamsets.pipeline.stage.destination.kudu.*;
+import junit.framework.Assert;
+import org.apache.kudu.ColumnSchema;
+import org.apache.kudu.Schema;
+import org.apache.kudu.Type;
+import org.apache.kudu.client.*;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.api.support.membermodification.MemberMatcher;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({
+    KuduTarget.class,
+    KuduClient.class,
+    KuduTable.class,
+    KuduSession.class,
+    Operation.class
+    })
+@PowerMockIgnore({ "javax.net.ssl.*" })
+public class TestKuduLookup {
+
+  private static final String KUDU_MASTER = "localhost:7051";
+  private final String tableName = "test";
+
+  @Before
+  public void setup() {
+
+    final KuduClient client = new KuduClient.KuduClientBuilder(KUDU_MASTER).build();
+
+    // Create a dummy kuduSession
+    PowerMockito.replace(
+        MemberMatcher.method(
+            KuduTarget.class,
+            "openKuduSession",
+            List.class
+        )
+    ).with(new InvocationHandler() {
+      @Override
+      public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+        return client.newSession();
+      }
+    });
+
+    // Sample table and schema
+    List<ColumnSchema> columns = new ArrayList(2);
+    columns.add(new ColumnSchema.ColumnSchemaBuilder("key", Type.INT32).key(true).build());
+    columns.add(new ColumnSchema.ColumnSchemaBuilder("value", Type.STRING).build());
+    columns.add(new ColumnSchema.ColumnSchemaBuilder("name", Type.STRING).build());
+    final Schema schema = new Schema(columns);
+
+    // Mock KuduTable class
+    KuduTable table = PowerMockito.spy(PowerMockito.mock(KuduTable.class));
+    PowerMockito.stub(
+        PowerMockito.method(KuduClient.class, "openTable"))
+        .toReturn(table);
+    PowerMockito.suppress(PowerMockito.method(KuduClient.class, "getTablesList"));
+    PowerMockito.stub(PowerMockito.method(KuduClient.class, "tableExists")).toReturn(true);
+    PowerMockito.when(table.getSchema()).thenReturn(schema);
+
+    // Mock KuduSession class
+    PowerMockito.suppress(PowerMockito.method(
+        KuduSession.class,
+        "apply",
+        Operation.class
+    ));
+    PowerMockito.suppress(PowerMockito.method(
+        KuduSession.class,
+        "flush"
+    ));
+  }
+
+  @Test
+  public void testConnectionFailure() throws Exception{
+    // Mock connection refused
+    PowerMockito.stub(
+        PowerMockito.method(KuduClient.class, "getTablesList"))
+        .toThrow(PowerMockito.mock(KuduException.class));
+
+    ProcessorRunner runner = setProcessorRunner(tableName);
+
+    try {
+      List<Stage.ConfigIssue> issues = runner.runValidateConfigs();
+      Assert.assertEquals(1, issues.size());
+    } catch (StageException e) {
+      Assert.fail("should not throw StageException");
+    }
+  }
+
+  /**
+   * If table name template is not EL, we access Kudu and check if the table exists.
+   * This test checks when Kudu returned true for tableExists() method.
+   * @throws Exception
+   */
+  @Test
+  public void testTableExistsNoEL() throws Exception{
+    ProcessorRunner runner = setProcessorRunner(tableName);
+
+    try {
+      List<Stage.ConfigIssue> issues = runner.runValidateConfigs();
+      Assert.assertEquals(0, issues.size());
+    } catch (StageException e){
+      Assert.fail();
+    }
+  }
+
+  /**
+   * If table name template is not EL, we access Kudu and check if the table exists.
+   * This test checks when Kudu's tableExists() method returns false.
+   * @throws Exception
+   */
+  @Test
+  public void testTableDoesNotExistNoEL() throws Exception{
+    // Mock table doesn't exist in Kudu.
+    PowerMockito.stub(PowerMockito.method(KuduClient.class, "openTable"))
+        .toThrow(PowerMockito.mock(KuduException.class));
+
+    ProcessorRunner runner = setProcessorRunner(tableName);
+
+    try {
+      List<Stage.ConfigIssue> issues = runner.runValidateConfigs();
+      Assert.assertEquals(1, issues.size());
+    } catch (StageException e){
+      Assert.fail();
+    }
+  }
+
+  private ProcessorRunner setProcessorRunner(String tableName)
+  {
+    KuduLookupConfig conf = new KuduLookupConfig();
+    conf.kuduMaster = KUDU_MASTER;
+    conf.kuduTable = tableName;
+    conf.fieldMappingConfigs = new ArrayList<>();
+    conf.fieldMappingConfigs.add(new KuduFieldMappingConfig("/key", "key"));
+    conf.fieldMappingConfigs.add(new KuduFieldMappingConfig("/value", "value"));
+    KuduLookupProcessor processor = new KuduLookupProcessor(conf);
+    return new ProcessorRunner.Builder(KuduLookupProcessor.class, processor)
+        .setOnRecordError(OnRecordError.TO_ERROR)
+        .addOutputLane("lane")
+        .build();
+  }
+}


### PR DESCRIPTION
* All primary keys on the target table must be specified in the record
 or a record error is generated
* Unit tests need to be expanded
* Never tested against a secure cluster