### PR TITLE
Copy Rabbit headers in as StreamSets headers

### DIFF
--- a/rabbitmq-lib/src/main/java/com/streamsets/pipeline/stage/origin/rabbitmq/RabbitSource.java
+++ b/rabbitmq-lib/src/main/java/com/streamsets/pipeline/stage/origin/rabbitmq/RabbitSource.java
@@ -123,30 +123,30 @@ public class RabbitSource extends BaseSource implements OffsetCommitter {
           BasicProperties properties = message.getProperties();
           Record.Header outHeader = record.getHeader();
           if (envelope != null) {
-            outHeader.setAttribute("deliveryTag", convToString(envelope.getDeliveryTag()));
-            outHeader.setAttribute("exchange", convToString(envelope.getExchange()));
-            outHeader.setAttribute("routingKey", convToString(envelope.getRoutingKey()));
-            outHeader.setAttribute("redelivered", convToString(envelope.isRedeliver()));
+            setHeaderIfNotNull(outHeader, "deliveryTag", envelope.getDeliveryTag());
+            setHeaderIfNotNull(outHeader, "exchange", envelope.getExchange());
+            setHeaderIfNotNull(outHeader, "routingKey", envelope.getRoutingKey());
+            setHeaderIfNotNull(outHeader, "redelivered", envelope.isRedeliver());
           }
-          outHeader.setAttribute("contentType", convToString(properties.getContentType()));
-          outHeader.setAttribute("contentEncoding", convToString(properties.getContentEncoding()));
-          outHeader.setAttribute("deliveryMode", convToString(properties.getDeliveryMode()));
-          outHeader.setAttribute("priority", convToString(properties.getPriority()));
-          outHeader.setAttribute("correlationId", convToString(properties.getCorrelationId()));
-          outHeader.setAttribute("replyTo", convToString(properties.getReplyTo()));
-          outHeader.setAttribute("expiration", convToString(properties.getExpiration()));
-          outHeader.setAttribute("messageId", convToString(properties.getMessageId()));
-          outHeader.setAttribute("timestamp", convToString(properties.getTimestamp()));
-          outHeader.setAttribute("messageType", convToString(properties.getType()));
-          outHeader.setAttribute("userId", convToString(properties.getUserId()));
-          outHeader.setAttribute("appId", convToString(properties.getAppId()));
+          setHeaderIfNotNull(outHeader, "contentType", properties.getContentType());
+          setHeaderIfNotNull(outHeader, "contentEncoding", properties.getContentEncoding());
+          setHeaderIfNotNull(outHeader, "deliveryMode", properties.getDeliveryMode());
+          setHeaderIfNotNull(outHeader, "priority", properties.getPriority());
+          setHeaderIfNotNull(outHeader, "correlationId", properties.getCorrelationId());
+          setHeaderIfNotNull(outHeader, "replyTo", properties.getReplyTo());
+          setHeaderIfNotNull(outHeader, "expiration", properties.getExpiration());
+          setHeaderIfNotNull(outHeader, "messageId", properties.getMessageId());
+          setHeaderIfNotNull(outHeader, "timestamp", properties.getTimestamp());
+          setHeaderIfNotNull(outHeader, "messageType", properties.getType());
+          setHeaderIfNotNull(outHeader, "userId", properties.getUserId());
+          setHeaderIfNotNull(outHeader, "appId", properties.getAppId());
           Map<String, Object> inHeaders = properties.getHeaders();
           if (inHeaders != null) {
             for (Map.Entry<String, Object> pair : inHeaders.entrySet()) {
               // I am concerned about overlapping with the above headers but it seems somewhat unlikely
               // in addition the behavior of copying these attributes in with no custom prefix is
               // how the jms origin behaves
-              outHeader.setAttribute(pair.getKey(), convToString(pair.getValue()));
+              setHeaderIfNotNull(outHeader, pair.getKey(), convToString(pair.getValue()));
             }
           }
           batchMaker.addRecord(record);
@@ -160,10 +160,13 @@ public class RabbitSource extends BaseSource implements OffsetCommitter {
     return nextSourceOffset;
   }
 
-  private static String convToString(Object o) {
-    if (o == null) {
-      return "";
+  private void setHeaderIfNotNull(Record.Header header, String key, Object val) {
+    if (val != null) {
+      header.setAttribute(key, convToString(val));
     }
+  }
+
+  private static String convToString(Object o) {
     if (o instanceof Date) {
       o = ((Date)o).getTime();
     }

--- a/rabbitmq-lib/src/main/java/com/streamsets/pipeline/stage/origin/rabbitmq/RabbitSource.java
+++ b/rabbitmq-lib/src/main/java/com/streamsets/pipeline/stage/origin/rabbitmq/RabbitSource.java
@@ -177,7 +177,7 @@ public class RabbitSource extends BaseSource implements OffsetCommitter {
     }
 
     try {
-      consumer.getChannel().basicAck(Long.parseLong(offset), true); // true is
+      consumer.getChannel().basicAck(Long.parseLong(offset), true);
       lastSourceOffset = offset;
     } catch (IOException e) {
       LOG.error("Failed to acknowledge offset: {}", offset, e);

--- a/rabbitmq-lib/src/main/java/com/streamsets/pipeline/stage/origin/rabbitmq/RabbitSource.java
+++ b/rabbitmq-lib/src/main/java/com/streamsets/pipeline/stage/origin/rabbitmq/RabbitSource.java
@@ -146,7 +146,7 @@ public class RabbitSource extends BaseSource implements OffsetCommitter {
               // I am concerned about overlapping with the above headers but it seems somewhat unlikely
               // in addition the behavior of copying these attributes in with no custom prefix is
               // how the jms origin behaves
-              setHeaderIfNotNull(outHeader, pair.getKey(), convToString(pair.getValue()));
+              setHeaderIfNotNull(outHeader, pair.getKey(), pair.getValue());
             }
           }
           batchMaker.addRecord(record);

--- a/rabbitmq-lib/src/test/java/com/streamsets/pipeline/stage/origin/rabbitmq/RabbitSourceTest.java
+++ b/rabbitmq-lib/src/test/java/com/streamsets/pipeline/stage/origin/rabbitmq/RabbitSourceTest.java
@@ -15,10 +15,19 @@
  */
 package com.streamsets.pipeline.stage.origin.rabbitmq;
 
+import com.rabbitmq.client.AMQP;
+import com.rabbitmq.client.Channel;
+import com.rabbitmq.client.Consumer;
+import com.rabbitmq.client.Envelope;
+import com.streamsets.pipeline.api.Record;
 import com.streamsets.pipeline.api.Source;
 import com.streamsets.pipeline.api.Stage;
 import com.streamsets.pipeline.api.StageException;
 import com.streamsets.pipeline.api.base.BaseStage;
+import com.streamsets.pipeline.config.JsonMode;
+import com.streamsets.pipeline.lib.parser.DataParserFactory;
+import com.streamsets.pipeline.lib.parser.DataParserFactoryBuilder;
+import com.streamsets.pipeline.lib.parser.DataParserFormat;
 import com.streamsets.pipeline.sdk.SourceRunner;
 import com.streamsets.pipeline.sdk.StageRunner;
 import org.junit.Before;
@@ -26,16 +35,36 @@ import org.junit.Test;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.LinkedTransferQueue;
+import java.util.concurrent.TransferQueue;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
 
 @PrepareForTest(RabbitSource.class)
 public class RabbitSourceTest extends BaseRabbitStageTest{
+  private static final String CONSUMER_TAG = "c1";
+  private static final String QUEUE_NAME = "hello";
+  private static final String EXCHANGE_NAME = "";
+  private static final String TEST_MESSAGE_1 = "{\"field1\": \"abcdef\"}";
+  private static final String CLUSTER_ID = "cluster-1";
+  private static final long DELIVERY_TAG = 1;
+  private static final boolean REDELIVERED = false;
+  private static final String CUSTOM_HEADER_KEY = "k1";
+  private static final String CUSTOM_HEADER_VAL = "v1";
+  private static final String CONTENT_TYPE = "application/json";
 
   @Before
-  public void setup() { this.conf = new RabbitSourceConfigBean();}
+  public void setup() {
+    this.conf = new RabbitSourceConfigBean();
+  }
 
   @Override
   protected StageRunner newStageRunner(String outputLane) {
@@ -79,4 +108,53 @@ public class RabbitSourceTest extends BaseRabbitStageTest{
     runner.runDestroy();
   }
 
+  @Test
+  public void testHeaderProcessing() throws Exception {
+    ((RabbitSourceConfigBean)conf).basicConfig.maxWaitTime = 1000; // Set this low so that we don't slow down the test.
+
+    stage = PowerMockito.spy(newStage());
+
+    // setup some fake data and force it onto the source's queue
+    RabbitSource source = (RabbitSource)stage;
+    TransferQueue<RabbitMessage> messages = source.getMessageQueue();
+    Envelope envelope = new Envelope(DELIVERY_TAG, REDELIVERED, EXCHANGE_NAME, QUEUE_NAME);
+    AMQP.BasicProperties.Builder propertiesBuilder = new AMQP.BasicProperties.Builder();
+    propertiesBuilder.contentType(CONTENT_TYPE);
+    Map<String, Object> customHeaders = new HashMap<>();
+    customHeaders.put(CUSTOM_HEADER_KEY, CUSTOM_HEADER_VAL);
+    propertiesBuilder.headers(customHeaders);
+    propertiesBuilder.clusterId(CLUSTER_ID);
+    AMQP.BasicProperties properties = propertiesBuilder.build();
+    RabbitMessage msg = new RabbitMessage(CONSUMER_TAG, envelope, properties, TEST_MESSAGE_1.getBytes());
+    source.getMessageQueue().put(msg);
+    doReturn(new ArrayList<Stage.ConfigIssue>()).when((RabbitSource)stage).init();
+
+    PowerMockito.doReturn(false).when(stage, "isConnected");
+
+    this.runner = newStageRunner("output");
+
+    // setup items which are not correctly configured in init
+    Channel channel = mock(Channel.class);
+    StreamSetsMessageConsumer consumer = new StreamSetsMessageConsumer(channel, messages);
+    source.setStreamSetsMessageConsumer(consumer);
+    DataParserFactory parserFactory = new DataParserFactoryBuilder(runner.getContext(), DataParserFormat.JSON)
+        .setCharset(StandardCharsets.UTF_8)
+        .setMode(JsonMode.MULTIPLE_OBJECTS)
+        .setMaxDataLen(-1)
+        .build();
+    source.setDataParserFactory(parserFactory);
+
+    runner.runInit();
+
+    StageRunner.Output output = ((SourceRunner)runner).runProduce(null, 1000);
+    List<Record> records = output.getRecords().get("output");
+    assertEquals(1, records.size());
+    Record record = records.get(0);
+    assertEquals(String.valueOf(DELIVERY_TAG), record.getHeader().getAttribute("deliveryTag"));
+    assertEquals(String.valueOf(REDELIVERED), record.getHeader().getAttribute("redelivered"));
+    assertEquals(EXCHANGE_NAME, record.getHeader().getAttribute("exchange"));
+    assertEquals(CONTENT_TYPE, record.getHeader().getAttribute("contentType"));
+    assertEquals(CUSTOM_HEADER_VAL, record.getHeader().getAttribute(CUSTOM_HEADER_KEY));
+    runner.runDestroy();
+  }
 }

--- a/rabbitmq-lib/src/test/java/com/streamsets/pipeline/stage/origin/rabbitmq/RabbitSourceTest.java
+++ b/rabbitmq-lib/src/test/java/com/streamsets/pipeline/stage/origin/rabbitmq/RabbitSourceTest.java
@@ -17,7 +17,6 @@ package com.streamsets.pipeline.stage.origin.rabbitmq;
 
 import com.rabbitmq.client.AMQP;
 import com.rabbitmq.client.Channel;
-import com.rabbitmq.client.Consumer;
 import com.rabbitmq.client.Envelope;
 import com.streamsets.pipeline.api.Record;
 import com.streamsets.pipeline.api.Source;
@@ -40,10 +39,10 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.LinkedTransferQueue;
 import java.util.concurrent.TransferQueue;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -154,6 +153,7 @@ public class RabbitSourceTest extends BaseRabbitStageTest{
     assertEquals(String.valueOf(REDELIVERED), record.getHeader().getAttribute("redelivered"));
     assertEquals(EXCHANGE_NAME, record.getHeader().getAttribute("exchange"));
     assertEquals(CONTENT_TYPE, record.getHeader().getAttribute("contentType"));
+    assertNull(record.getHeader().getAttribute("appId"));
     assertEquals(CUSTOM_HEADER_VAL, record.getHeader().getAttribute(CUSTOM_HEADER_KEY));
     runner.runDestroy();
   }

--- a/rabbitmq-lib/src/test/java/com/streamsets/pipeline/stage/origin/rabbitmq/TestStreamSetsMessageConsumer.java
+++ b/rabbitmq-lib/src/test/java/com/streamsets/pipeline/stage/origin/rabbitmq/TestStreamSetsMessageConsumer.java
@@ -69,12 +69,6 @@ public class TestStreamSetsMessageConsumer {
   public void testConsumerSingleMessage() throws Exception {
     TransferQueue<RabbitMessage> messages = new LinkedTransferQueue<>();
 
-    DataParserFactory parserFactory = new DataParserFactoryBuilder(context, DataParserFormat.JSON)
-        .setCharset(StandardCharsets.UTF_8)
-        .setMode(JsonMode.MULTIPLE_OBJECTS)
-        .setMaxDataLen(-1)
-        .build();
-
     Channel channel = mock(Channel.class);
 
     final Consumer consumer = new StreamSetsMessageConsumer(channel, messages);


### PR DESCRIPTION
Straightforward patch. Adds test which relies on mocked components like the other tests.