### PR TITLE
Patch for allowing users to supply / extract custom query parameters …

### DIFF
--- a/basic-lib/src/main/java/com/streamsets/pipeline/stage/origin/httpserver/PushHttpReceiver.java
+++ b/basic-lib/src/main/java/com/streamsets/pipeline/stage/origin/httpserver/PushHttpReceiver.java
@@ -124,6 +124,15 @@ public class PushHttpReceiver implements HttpReceiver {
 
     // parse request into records
     List<Record> records = new ArrayList<>();
+
+    //begin fix for obtaining custom query parameters.
+    Map<String,Object> httpQueryParams = new HashMap<>();
+    req.getParameterMap().entrySet().forEach(entry ->{
+      httpQueryParams.put(entry.getKey(),String.join(",",entry.getValue()));
+    });
+    //end extraction of query parameters from http request.
+
+
     String requestId = System.currentTimeMillis() + "." + counter.getAndIncrement();
     try (DataParser parser = getParserFactory().getParser(requestId, is, "0")) {
       Record record = parser.parse();
@@ -137,6 +146,9 @@ public class PushHttpReceiver implements HttpReceiver {
 
     // dispatch records to batch
     for (Record record : records) {
+      //push the http query parameters in every record header.
+      record.getHeader().setAllAttributes(httpQueryParams);
+      //end push http query parameters in every record header.	
       batchContext.getBatchMaker().addRecord(record);
     }
 


### PR DESCRIPTION
We have a pipeline with http server as origin and a custom processor for normalising csv records. The normalisation happens via a rest call that in turn returns the file format definition for the file being normalized.

As such we need to send two parameters one is the filename and the other being the pipeline mode (whether it is a dry run or a live upload)

based on the filename, we retrieve the metadata about the file format, field definitions etc.
based on the pipeline mode we decide whether to push the normalized record into the live topic or dry run topic.

presently, the http server origin does not provide any information about the file being uploaded nor it passes on the query parameters to record headers to other stage components.

This patch addresses this issue.
Attaching the sample pipeline.
<img width="907" alt="pipeline" src="https://user-images.githubusercontent.com/3691978/28992648-b851e020-79bf-11e7-8d0c-905e41c75a09.png">
