### PR TITLE
JDBC connection using Oracle Wallet fails with 'java.sql.SQLException…

### DIFF
--- a/jdbc-lib/src/main/java/com/streamsets/pipeline/lib/jdbc/JdbcUtil.java
+++ b/jdbc-lib/src/main/java/com/streamsets/pipeline/lib/jdbc/JdbcUtil.java
@@ -689,8 +689,10 @@ public class JdbcUtil {
     });
 
     config.setJdbcUrl(hikariConfigBean.connectionString);
-    config.setUsername(hikariConfigBean.username.get());
-    config.setPassword(hikariConfigBean.password.get());
+    if (hikariConfigBean.useCredentials){
+       config.setUsername(hikariConfigBean.username.get());
+       config.setPassword(hikariConfigBean.password.get());
+    }
     config.setAutoCommit(autoCommit);
     config.setReadOnly(readOnly);
     config.setMaximumPoolSize(hikariConfigBean.maximumPoolSize);


### PR DESCRIPTION
…: ORA-01017: invalid username/password; logon denied' message.

Streamsets is passing empty string for username and password to Hikari Connection Pool even when 'Use Credentials' option is unchecked (JDBCProducer).
It should not pass username and password  when 'Use Credentials' option is unchecked.
Code snippet to reproduce the issue using HikariCP:

import com.zaxxer.hikari.HikariConfig;
import com.zaxxer.hikari.HikariDataSource;
import java.sql.*;

public class TestHikariPool {
  public static void main(String[] args) throws SQLException {

    HikariConfig config = new HikariConfig();
    config.setDriverClassName("oracle.jdbc.OracleDriver");
    config.setJdbcUrl("jdbc:oracle:thin:/@OW_OLH_MIDAS");

    // Works
    //config.setUsername(null);
    //config.setPassword(null);

    // Fails
    config.setUsername("");
    config.setPassword("");

    HikariDataSource ds = new HikariDataSource(config);

    Connection conn = ds.getConnection();
    conn.setAutoCommit(false);
    Statement stmt = conn.createStatement();
    ResultSet rset = stmt.executeQuery("select user from dual");
    while (rset.next()) {
       System.out.println (rset.getString(1));
    }
    stmt.close();

    System.out.println ("Success!");
  }
}
![wallet_test_output](https://user-images.githubusercontent.com/6625381/31020234-64503546-a500-11e7-9727-f8a2d4f286ef.jpg)
