### PR TITLE
connectionTimeout input value is in seconds, while jedis expects milliseconds

### DIFF
--- a/redis-lib/src/main/java/com/streamsets/pipeline/stage/destination/redis/RedisTarget.java
+++ b/redis-lib/src/main/java/com/streamsets/pipeline/stage/destination/redis/RedisTarget.java
@@ -175,7 +175,7 @@ public class RedisTarget extends BaseTarget {
 
   private void getRedisConnection() {
     JedisPoolConfig poolConfig = new JedisPoolConfig();
-    pool = new JedisPool(poolConfig, URI.create(conf.uri), conf.connectionTimeout);
+    pool = new JedisPool(poolConfig, URI.create(conf.uri), conf.connectionTimeout * 1000); // connectionTimeout value is in seconds
     String userInfo = URI.create(conf.uri).getUserInfo();
     jedis = pool.getResource();
     if (userInfo != null && userInfo.split(":", 2).length > 0) {

--- a/redis-lib/src/main/java/com/streamsets/pipeline/stage/processor/kv/redis/RedisLookupProcessor.java
+++ b/redis-lib/src/main/java/com/streamsets/pipeline/stage/processor/kv/redis/RedisLookupProcessor.java
@@ -83,7 +83,7 @@ public class RedisLookupProcessor extends BaseProcessor {
     JedisPool pool = null;
 
     try {
-      pool = new JedisPool(poolConfig, URI.create(conf.uri), conf.connectionTimeout);
+      pool = new JedisPool(poolConfig, URI.create(conf.uri), conf.connectionTimeout * 1000); // connectionTimeout value is in seconds
       Jedis jedis = pool.getResource();
       jedis.ping();
       jedis.close();

--- a/redis-lib/src/main/java/com/streamsets/pipeline/stage/processor/kv/redis/RedisStore.java
+++ b/redis-lib/src/main/java/com/streamsets/pipeline/stage/processor/kv/redis/RedisStore.java
@@ -41,7 +41,7 @@ public class RedisStore extends CacheLoader<Pair<String, DataType>, LookupValue>
     final JedisPoolConfig poolConfig = new JedisPoolConfig();
     poolConfig.setBlockWhenExhausted(true);
 
-    pool = new JedisPool(poolConfig, URI.create(conf.uri), conf.connectionTimeout);
+    pool = new JedisPool(poolConfig, URI.create(conf.uri), conf.connectionTimeout * 1000); // connectionTimeout value is in seconds
   }
 
   @Override


### PR DESCRIPTION
connectionTimeout input value is in seconds, while jedis expects milliseconds, a multiplication of 1000 is necessary.