### PR TITLE
connectionTimeout input value is in seconds, while jedis expects millisecs

### DIFF
--- a/redis-lib/src/main/java/com/streamsets/pipeline/stage/destination/redis/RedisTarget.java
+++ b/redis-lib/src/main/java/com/streamsets/pipeline/stage/destination/redis/RedisTarget.java
@@ -51,6 +51,8 @@ public class RedisTarget extends BaseTarget {
   private static final Logger LOG = LoggerFactory.getLogger(RedisTarget.class);
   private final RedisTargetConfig conf;
   private int retries;
+  
+  private final int MILLIS = 1000;
 
   public RedisTarget(RedisTargetConfig conf) {
     this.conf = conf;
@@ -175,7 +177,7 @@ public class RedisTarget extends BaseTarget {
 
   private void getRedisConnection() {
     JedisPoolConfig poolConfig = new JedisPoolConfig();
-    pool = new JedisPool(poolConfig, URI.create(conf.uri), conf.connectionTimeout * 1000); // connectionTimeout value is in seconds
+    pool = new JedisPool(poolConfig, URI.create(conf.uri), conf.connectionTimeout * MILLIS); // connectionTimeout value is in seconds
     String userInfo = URI.create(conf.uri).getUserInfo();
     jedis = pool.getResource();
     if (userInfo != null && userInfo.split(":", 2).length > 0) {
@@ -265,8 +267,8 @@ public class RedisTarget extends BaseTarget {
         retries++;
         LOG.debug("Redis connection retry: " + retries);
         try {
-          LOG.trace("Sleeping for: {}", conf.connectionTimeout);
-          ThreadUtil.sleep(conf.connectionTimeout);
+          LOG.trace("Sleeping for: {}", conf.connectionTimeout * MILLIS);
+          ThreadUtil.sleep(conf.connectionTimeout * MILLIS);
           getRedisConnection();
         } catch (JedisException e) {
           //no-op

--- a/redis-lib/src/main/java/com/streamsets/pipeline/stage/destination/redis/RedisTarget.java
+++ b/redis-lib/src/main/java/com/streamsets/pipeline/stage/destination/redis/RedisTarget.java
@@ -175,7 +175,7 @@ public class RedisTarget extends BaseTarget {
 
   private void getRedisConnection() {
     JedisPoolConfig poolConfig = new JedisPoolConfig();
-    pool = new JedisPool(poolConfig, URI.create(conf.uri), conf.connectionTimeout);
+    pool = new JedisPool(poolConfig, URI.create(conf.uri), conf.connectionTimeout * 1000); // connectionTimeout value is in seconds
     String userInfo = URI.create(conf.uri).getUserInfo();
     jedis = pool.getResource();
     if (userInfo != null && userInfo.split(":", 2).length > 0) {

--- a/redis-lib/src/main/java/com/streamsets/pipeline/stage/destination/redis/RedisTargetConfig.java
+++ b/redis-lib/src/main/java/com/streamsets/pipeline/stage/destination/redis/RedisTargetConfig.java
@@ -42,13 +42,13 @@ public class RedisTargetConfig {
   @ConfigDef(
       type = ConfigDef.Type.NUMBER,
       label = "Connection Timeout (sec)",
-      defaultValue = "1000",
+      defaultValue = "60",
       required = true,
       min = 1,
       displayPosition = 20,
       group = "REDIS"
   )
-  public int connectionTimeout = 1000;
+  public int connectionTimeout = 60;
 
   @ConfigDef(
       type = ConfigDef.Type.NUMBER,

--- a/redis-lib/src/main/java/com/streamsets/pipeline/stage/origin/redis/BaseRedisSource.java
+++ b/redis-lib/src/main/java/com/streamsets/pipeline/stage/origin/redis/BaseRedisSource.java
@@ -98,7 +98,7 @@ public abstract class BaseRedisSource extends BaseSource {
     boolean isOk = true;
     if (null == redisClient) {
       try {
-        redisClient = new Jedis(URI.create(conf.uri), conf.connectionTimeout);
+        redisClient = new Jedis(URI.create(conf.uri), conf.connectionTimeout * 1000); // connectionTimeout value is in seconds
       } catch (Exception e) {
         LOG.error("Can't create redis client", e);
         issues.add(getContext().createConfigIssue(Groups.REDIS.name(), "uri", Errors.REDIS_01, conf.uri, e.toString()));

--- a/redis-lib/src/main/java/com/streamsets/pipeline/stage/processor/kv/redis/RedisLookupProcessor.java
+++ b/redis-lib/src/main/java/com/streamsets/pipeline/stage/processor/kv/redis/RedisLookupProcessor.java
@@ -83,7 +83,7 @@ public class RedisLookupProcessor extends BaseProcessor {
     JedisPool pool = null;
 
     try {
-      pool = new JedisPool(poolConfig, URI.create(conf.uri), conf.connectionTimeout);
+      pool = new JedisPool(poolConfig, URI.create(conf.uri), conf.connectionTimeout * 1000); // connectionTimeout value is in seconds
       Jedis jedis = pool.getResource();
       jedis.ping();
       jedis.close();

--- a/redis-lib/src/main/java/com/streamsets/pipeline/stage/processor/kv/redis/RedisStore.java
+++ b/redis-lib/src/main/java/com/streamsets/pipeline/stage/processor/kv/redis/RedisStore.java
@@ -41,7 +41,7 @@ public class RedisStore extends CacheLoader<Pair<String, DataType>, LookupValue>
     final JedisPoolConfig poolConfig = new JedisPoolConfig();
     poolConfig.setBlockWhenExhausted(true);
 
-    pool = new JedisPool(poolConfig, URI.create(conf.uri), conf.connectionTimeout);
+    pool = new JedisPool(poolConfig, URI.create(conf.uri), conf.connectionTimeout * 1000); // connectionTimeout value is in seconds
   }
 
   @Override


### PR DESCRIPTION
connectionTimeout input value is in seconds, while jedis expects milliseconds, a multiplication of 1000 is necessary.