### PR TITLE
SDC-5463. Changed rabbit-mq expiration type from short to int

### DIFF
--- a/rabbitmq-lib/src/main/java/com/streamsets/pipeline/stage/destination/rabbitmq/BasicPropertiesConfig.java
+++ b/rabbitmq-lib/src/main/java/com/streamsets/pipeline/stage/destination/rabbitmq/BasicPropertiesConfig.java
@@ -137,7 +137,7 @@ public class BasicPropertiesConfig {
       triggeredByValue = "true",
       group = "#0"
   )
-  public short expiration = 0;
+  public int expiration = 0;
 
   @ConfigDef(
       required = false,


### PR DESCRIPTION
Int should be fine for all 4 usages of this variable. RabbitMQ's short str has a limit of 255 chars. String.valueOf(expiration) should not cause any problems when expiration has type int.  