### PR TITLE
SDC-7953. Improve Oracle CDC Config parser for more flexability

### DIFF
--- a/jdbc-lib/src/main/java/com/streamsets/pipeline/stage/origin/jdbc/cdc/CDCSourceConfigBean.java
+++ b/jdbc-lib/src/main/java/com/streamsets/pipeline/stage/origin/jdbc/cdc/CDCSourceConfigBean.java
@@ -35,17 +35,6 @@ public class CDCSourceConfigBean {
 
   @ConfigDef(
       required = true,
-      type = ConfigDef.Type.BOOLEAN,
-      label = "Multitenancy",
-      description = "Define which configuration use, Use SQL patterns in Schema and Table to load metadata",
-      displayPosition = 5,
-      defaultValue = "false",
-      group = "CDC"
-  )
-  public boolean multitenancy;
-
-  @ConfigDef(
-      required = true,
       type = ConfigDef.Type.STRING,
       label = "Schema Name",
       displayPosition = 10,

--- a/jdbc-lib/src/main/java/com/streamsets/pipeline/stage/origin/jdbc/cdc/CDCSourceConfigBean.java
+++ b/jdbc-lib/src/main/java/com/streamsets/pipeline/stage/origin/jdbc/cdc/CDCSourceConfigBean.java
@@ -35,6 +35,17 @@ public class CDCSourceConfigBean {
 
   @ConfigDef(
       required = true,
+      type = ConfigDef.Type.BOOLEAN,
+      label = "Multitenancy",
+      description = "Define which configuration use, Use SQL patterns in Schema and Table to load metadata",
+      displayPosition = 5,
+      defaultValue = "false",
+      group = "CDC"
+  )
+  public boolean multitenancy;
+
+  @ConfigDef(
+      required = true,
       type = ConfigDef.Type.STRING,
       label = "Schema Name",
       displayPosition = 10,
@@ -50,6 +61,15 @@ public class CDCSourceConfigBean {
       group = "CDC"
   )
   public List<String> tables;
+
+  @ConfigDef(
+      required = false,
+      type = ConfigDef.Type.STRING,
+      label = "Exclude pattern",
+      displayPosition = 20,
+      group = "CDC"
+  )
+  public String excludePattern;
 
   @ConfigDef(
       required = true,

--- a/jdbc-lib/src/main/java/com/streamsets/pipeline/stage/origin/jdbc/cdc/CDCSourceConfigBean.java
+++ b/jdbc-lib/src/main/java/com/streamsets/pipeline/stage/origin/jdbc/cdc/CDCSourceConfigBean.java
@@ -55,6 +55,7 @@ public class CDCSourceConfigBean {
       required = false,
       type = ConfigDef.Type.STRING,
       label = "Exclude pattern",
+      description = "Regular expression which applies to both schema and table",
       displayPosition = 20,
       group = "CDC"
   )

--- a/jdbc-lib/src/main/java/com/streamsets/pipeline/stage/origin/jdbc/cdc/oracle/OracleCDCSource.java
+++ b/jdbc-lib/src/main/java/com/streamsets/pipeline/stage/origin/jdbc/cdc/oracle/OracleCDCSource.java
@@ -681,7 +681,7 @@ public class OracleCDCSource extends BaseSource {
     for (Map.Entry<String, String> column : columns.entrySet()) {
       String columnName = column.getKey();
       try {
-        fields.put(columnName, objectToField(table, columnName, column.getValue()));
+        fields.put(columnName, objectToField(attributes.get(SCHEMA) + "|" + table, columnName, column.getValue()));
       } catch (UnsupportedFieldTypeException ex) {
         if (configBean.sendUnsupportedFields) {
           fields.put(columnName, Field.create(column.getValue()));
@@ -1247,7 +1247,8 @@ public class OracleCDCSource extends BaseSource {
   private String formatTableList(List<String> tables) {
     List<String> quoted = new ArrayList<>(tables.size());
     for (String table : tables) {
-      quoted.add("'" + table + "'");
+      String[] schameTable = table.split("\\|");
+      quoted.add("'" + schameTable[1] + "'");
     }
     Joiner joiner = Joiner.on(',');
     return joiner.join(quoted);

--- a/jdbc-lib/src/main/java/com/streamsets/pipeline/stage/origin/jdbc/cdc/oracle/OracleCDCSource.java
+++ b/jdbc-lib/src/main/java/com/streamsets/pipeline/stage/origin/jdbc/cdc/oracle/OracleCDCSource.java
@@ -477,7 +477,7 @@ public class OracleCDCSource extends BaseSource {
             String rsId = resultSet.getString(13);
             Object ssn = resultSet.getObject(14);
             String schema = String.valueOf(resultSet.getString(15));
-            SchemaAndTable schemaAndTable = new SchemaAndTable(table, schema);
+            SchemaAndTable schemaAndTable = new SchemaAndTable(schema, table);
             String xid = xidUsn + "." + xidSlt + "." + xidSqn;
             TransactionIdKey key = new TransactionIdKey(xid);
             bufferedRecordsLock.lock();
@@ -780,12 +780,12 @@ public class OracleCDCSource extends BaseSource {
   private EventRecord createEventRecord(
       DDL_EVENT type,
       String redoSQL,
-      SchemaAndTable table,
+      SchemaAndTable schemaAndTable,
       String scnSeq,
       boolean sendSchema
   ) {
     EventRecord event = getContext().createEventRecord(type.name(), 1, scnSeq);
-    event.getHeader().setAttribute(TABLE, table.getTable());
+    event.getHeader().setAttribute(TABLE, schemaAndTable.getTable());
     if (redoSQL != null) {
       event.getHeader().setAttribute(DDL_TEXT, redoSQL);
     }
@@ -795,7 +795,7 @@ public class OracleCDCSource extends BaseSource {
       // We actually don't know the schema at table creation ever, but just the schema when we started. So
       // trying to figure out the schema at the time of the DDL is not really possible since this DDL could have occured
       // before the source started. Since we allow only types to be bigger and no column drops, this is ok.
-      Map<String, Integer> schema = tableSchemas.get(table);
+      Map<String, Integer> schema = tableSchemas.get(schemaAndTable);
       Map<String, Field> fields = new HashMap<>();
       for (Map.Entry<String, Integer> column : schema.entrySet()) {
         fields.put(column.getKey(), Field.create(JDBCTypeNames.get(column.getValue())));

--- a/jdbc-lib/src/main/java/com/streamsets/pipeline/stage/origin/jdbc/cdc/oracle/OracleCDCSource.java
+++ b/jdbc-lib/src/main/java/com/streamsets/pipeline/stage/origin/jdbc/cdc/oracle/OracleCDCSource.java
@@ -1006,15 +1006,12 @@ public class OracleCDCSource extends BaseSource {
           while (rs.next()) {
             String schemaName = rs.getString(TABLE_METADATA_TABLE_SCHEMA_CONSTANT);
             String tableName = rs.getString(TABLE_METADATA_TABLE_NAME_CONSTANT);
-            LOG.info("Found " + schemaName + ", " + tableName);
             if (p == null || (!p.matcher(tableName).matches() && !p.matcher(schemaName).matches())) {
-              LOG.info("Adding " + schemaName + ", " + tableName);
               tables.add(schemaName + "|" + tableName);
             }
           }
         }
       } else {
-        LOG.info("Using simple tables list");
         tables = new ArrayList<>(configBean.baseConfigBean.tables.size());
 
         for (String table : configBean.baseConfigBean.tables) {
@@ -1299,8 +1296,8 @@ public class OracleCDCSource extends BaseSource {
   private void validateTablePresence(Statement statement, List<String> tables, List<ConfigIssue> issues) {
     for (String table : tables) {
       try {
-          String[] schameTable = table.split("\\|");
-          statement.execute("SELECT * FROM \"" + schameTable[0] + "\".\"" + schameTable[1] + "\" WHERE 1 = 0");
+        String[] schameTable = table.split("\\|");
+        statement.execute("SELECT * FROM \"" + schameTable[0] + "\".\"" + schameTable[1] + "\" WHERE 1 = 0");
       } catch (SQLException ex) {
         StringBuilder sb = new StringBuilder("Table: ").append(table).append(" does not exist.");
         if (StringUtils.isEmpty(configBean.pdb)) {

--- a/jdbc-lib/src/main/java/com/streamsets/pipeline/stage/origin/jdbc/cdc/oracle/SchemaAndTable.java
+++ b/jdbc-lib/src/main/java/com/streamsets/pipeline/stage/origin/jdbc/cdc/oracle/SchemaAndTable.java
@@ -22,46 +22,38 @@ import org.apache.commons.lang.StringUtils;
  */
 public class SchemaAndTable {
 
-    private String schema;
-    private String table;
+  private final String schema;
+  private final String table;
 
-    public SchemaAndTable(String schema, String table) {
-        this.schema = schema;
-        this.table = table;
-    }
+  public SchemaAndTable(String schema, String table) {
+    this.schema = schema;
+    this.table = table;
+  }
 
-    public String getSchema() {
-        return schema;
-    }
+  public String getSchema() {
+    return schema;
+  }
 
-    public void setSchema(String schema) {
-        this.schema = schema;
-    }
+  public String getTable() {
+    return table;
+  }
 
-    public String getTable() {
-        return table;
-    }
+  public boolean isNotEmpty() {
+    return StringUtils.isNotEmpty(this.schema) && StringUtils.isNotEmpty(this.table);
+  }
 
-    public void setTable(String table) {
-        this.table = table;
+  @Override
+  public boolean equals(Object o) {
+    if (o instanceof SchemaAndTable) {
+      SchemaAndTable sat = (SchemaAndTable) o;
+      return StringUtils.equals(sat.getSchema(), this.schema) &&
+              StringUtils.equals(sat.getTable(), this.table);
     }
+    return false;
+  }
 
-    public boolean isNotEmpty() {
-        return StringUtils.isNotEmpty(this.schema) && StringUtils.isNotEmpty(this.table);
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (o instanceof SchemaAndTable) {
-            SchemaAndTable sat = (SchemaAndTable) o;
-            return StringUtils.equals(sat.getSchema(), this.schema) &&
-                    StringUtils.equals(sat.getTable(), this.table);
-        }
-        return false;
-    }
-
-    @Override
-    public int hashCode() {
-        return this.schema.hashCode() + this.table.hashCode();
-    }
+  @Override
+  public int hashCode() {
+    return this.schema.hashCode() + this.table.hashCode();
+  }
 }

--- a/jdbc-lib/src/main/java/com/streamsets/pipeline/stage/origin/jdbc/cdc/oracle/SchemaAndTable.java
+++ b/jdbc-lib/src/main/java/com/streamsets/pipeline/stage/origin/jdbc/cdc/oracle/SchemaAndTable.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2017 StreamSets Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.streamsets.pipeline.stage.origin.jdbc.cdc.oracle;
+
+import org.apache.commons.lang.StringUtils;
+
+/**
+ * This class is to keep schema and table relation.
+ */
+public class SchemaAndTable {
+
+    private String schema;
+    private String table;
+
+    public SchemaAndTable(String schema, String table) {
+        this.schema = schema;
+        this.table = table;
+    }
+
+    public String getSchema() {
+        return schema;
+    }
+
+    public void setSchema(String schema) {
+        this.schema = schema;
+    }
+
+    public String getTable() {
+        return table;
+    }
+
+    public void setTable(String table) {
+        this.table = table;
+    }
+
+    public boolean isNotEmpty() {
+        return StringUtils.isNotEmpty(this.schema) && StringUtils.isNotEmpty(this.table);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o instanceof SchemaAndTable) {
+            SchemaAndTable sat = (SchemaAndTable) o;
+            return StringUtils.equals(sat.getSchema(), this.schema) &&
+                    StringUtils.equals(sat.getTable(), this.table);
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return this.schema.hashCode() + this.table.hashCode();
+    }
+}


### PR DESCRIPTION
Allows to select wide range of schemas and tables instead of creating many pipelines for each schema. This fix seems for the next version.