### PR TITLE
Feature/es merge operation 3.x

### DIFF
--- a/commonlib/src/main/java/com/streamsets/pipeline/lib/operation/OperationType.java
+++ b/commonlib/src/main/java/com/streamsets/pipeline/lib/operation/OperationType.java
@@ -30,6 +30,7 @@ public class OperationType {
   public static final int UNSUPPORTED_CODE = 5;
   public static final int UNDELETE_CODE = 6;
   public static final int REPLACE_CODE = 7;
+  public static final int MERGE_CODE = 8;
 
   private static final BiMap<Integer, String> CODE_LABEL = new ImmutableBiMap.Builder<Integer, String>()
       .put(INSERT_CODE, "INSERT")
@@ -39,6 +40,7 @@ public class OperationType {
       .put(UNSUPPORTED_CODE, "UNSUPPORTED")
       .put(UNDELETE_CODE, "UNDELETE")
       .put(REPLACE_CODE, "REPLACE")
+      .put(MERGE_CODE, "MERGE")
       .build();
 
   private static final ImmutableMap<String, Integer> LABEL_CODE = new ImmutableMap.Builder<String, Integer>()
@@ -49,6 +51,7 @@ public class OperationType {
       .put("UNSUPPORTED", UNSUPPORTED_CODE)
       .put("UNDELETE", UNDELETE_CODE)
       .put("REPLACE", REPLACE_CODE)
+      .put("MERGE", MERGE_CODE)
       .build();
 
 

--- a/elasticsearch-protolib/src/main/java/com/streamsets/pipeline/stage/destination/elasticsearch/ElasticsearchOperationType.java
+++ b/elasticsearch-protolib/src/main/java/com/streamsets/pipeline/stage/destination/elasticsearch/ElasticsearchOperationType.java
@@ -25,6 +25,7 @@ public enum ElasticsearchOperationType implements Label {
   CREATE(OperationType.INSERT_CODE),
   UPDATE(OperationType.UPDATE_CODE),
   DELETE(OperationType.DELETE_CODE),
+  MERGE(OperationType.MERGE_CODE)
   ;
 
   final int code;
@@ -45,6 +46,8 @@ public enum ElasticsearchOperationType implements Label {
         return "UPDATE";
       case OperationType.DELETE_CODE:
         return "DELETE";
+      case OperationType.MERGE_CODE:
+        return "MERGE";
       default:
         return null;
     }

--- a/elasticsearch-protolib/src/main/java/com/streamsets/pipeline/stage/destination/elasticsearch/ElasticsearchTarget.java
+++ b/elasticsearch-protolib/src/main/java/com/streamsets/pipeline/stage/destination/elasticsearch/ElasticsearchTarget.java
@@ -376,6 +376,10 @@ public class ElasticsearchTarget extends BaseTarget {
         getOperationMetadata("update", index, type, id, parent, routing, op);
         op.append(String.format("{\"doc\":%s}%n", record));
         break;
+      case OperationType.MERGE_CODE:
+        getOperationMetadata("update", index, type, id, parent, routing, op);
+        op.append(String.format("{\"doc_as_upsert\": \"true\", \"doc\":%s}%n", record));
+        break;
       case OperationType.DELETE_CODE:
         getOperationMetadata("delete", index, type, id, parent, routing, op);
         break;

--- a/elasticsearch-protolib/src/test/java/com/streamsets/pipeline/stage/destination/elasticsearch/ElasticSearchTargetIT.java
+++ b/elasticsearch-protolib/src/test/java/com/streamsets/pipeline/stage/destination/elasticsearch/ElasticSearchTargetIT.java
@@ -673,12 +673,12 @@ public class ElasticSearchTargetIT extends ElasticsearchBaseIT {
       Map expected = ImmutableMap.builder().put("a", "New")  // field changed
               .put("existing", "not touched") // untouched fields left alone
               .put("nested", ImmutableMap.of( // can merge nested fields as well
-                 "one", "uno",        // nested and unchanged
-                 "two", "duo",       // nested and changed
-                 "three", "tres",    // nested and left alone
-                 "four", "quattour"  // nested new field added
+                 "one", "uno",                // nested and unchanged
+                 "two", "duo",                // nested and changed
+                 "three", "tres",             // nested and left alone
+                 "four", "quattour"           // nested new field added
               ))
-              .put("new", "fresh")           // new field added
+              .put("new", "fresh")            // new field added
               .put("index", "j")
               .put("type", "t").build();
 

--- a/elasticsearch-protolib/src/test/java/com/streamsets/pipeline/stage/destination/elasticsearch/ElasticSearchTargetIT.java
+++ b/elasticsearch-protolib/src/test/java/com/streamsets/pipeline/stage/destination/elasticsearch/ElasticSearchTargetIT.java
@@ -632,4 +632,67 @@ public class ElasticSearchTargetIT extends ElasticsearchBaseIT {
     }
   }
 
+  @Test
+  public void testMergeRecords() throws Exception {
+    // Use the index field as document ID.
+    Target target = createTarget(
+            "${time:now()}",
+            "${record:value('/index')}",
+            "docId",
+            ElasticsearchOperationType.MERGE,
+            "",
+            ""
+    );
+    TargetRunner runner = new TargetRunner.Builder(ElasticSearchDTarget.class, target).build();
+    try {
+      runner.runInit();
+      List<Record> records = new ArrayList<>();
+      Record record1 = RecordCreator.create();
+      record1.set(Field.create(ImmutableMap.of("a", Field.create("Old"), // field to be changed
+              "nested", Field.create(ImmutableMap.of("one", Field.create("uno"), // nested unchanged
+                      "two", Field.create("dos"),      // nested changed
+                      "three", Field.create("tres"))), // nested left alone
+              "existing", Field.create("not touched"), // left alone
+              "index", Field.create("j"), "type", Field.create("t")))); // index and mapping
+      Record record2 = RecordCreator.create();
+      record2.set(Field.create(ImmutableMap.of("a", Field.create("New"), // field changed
+              "nested", Field.create(ImmutableMap.of("one", Field.create("uno"), // nested unchanged
+                      "two", Field.create("duo"),          // nested changed
+                      "four", Field.create("quattour"))),  // nested new field added
+              "new", Field.create("fresh"),                // new field added
+              "index", Field.create("j"), "type", Field.create("t")))); // index and mapping
+      records.add(record1);
+      records.add(record2);
+      runner.runWrite(records);
+      Assert.assertTrue(runner.getErrorRecords().isEmpty());
+      Assert.assertTrue(runner.getErrors().isEmpty());
+
+      prepareElasticSearchServerForQueries();
+
+      // Second record must be merged into first record: "New" replaces "Old", etc.
+      Map expected = ImmutableMap.builder().put("a", "New")  // field changed
+              .put("existing", "not touched") // untouched fields left alone
+              .put("nested", ImmutableMap.of( // can merge nested fields as well
+                 "one", "uno",        // nested and unchanged
+                 "two", "duo",       // nested and changed
+                 "three", "tres",    // nested and left alone
+                 "four", "quattour"  // nested new field added
+              ))
+              .put("new", "fresh")           // new field added
+              .put("index", "j")
+              .put("type", "t").build();
+
+      SearchResponse response = esServer.client().prepareSearch("j").setTypes("t")
+              .setSearchType(SearchType.DEFAULT).execute().actionGet();
+      SearchHit[] hits = response.getHits().getHits();
+      Assert.assertEquals(1, hits.length);
+      Map got = hits[0].getSource();
+
+      Assert.assertEquals(expected, got);
+
+    } finally {
+      runner.runDestroy();
+    }
+  }
+
 }


### PR DESCRIPTION
Elasticsearch supports a "document level upsert" which is basically a merge operation:

- If the document does not exist during a merge operation, it is created/inserted as is.
- If the document does exist in the index during a merge operation, then all of the fields in the incoming document are merged with the existing document. Any fields with the same key take the value of the incoming document, any fields in the existing document not in the incoming document are left as is. This behavior works with nested fields as well.

Currently Streamsets does not support this operation in the Elasticsesarch destination.

This PR adds a new top-level `OperationType.MERGE`, that is leveraged by the `ElasticsearchTarget` to support document update using the `doc_as_upsert` value in the request.

This PR is an update of PR #48, but based off of master instead of the 2.7 series.