### PR TITLE
RabbitMQ Destination - Expiration Property issue - SDC-8371

### DIFF
--- a/rabbitmq-lib/src/main/java/com/streamsets/pipeline/lib/rabbitmq/common/RabbitUtil.java
+++ b/rabbitmq-lib/src/main/java/com/streamsets/pipeline/lib/rabbitmq/common/RabbitUtil.java
@@ -138,7 +138,7 @@ public final class RabbitUtil {
 
     builder.deliveryMode(basicPropertiesConfig.deliveryMode.getDeliveryMode());
 
-    if (basicPropertiesConfig.expiration < 0) {
+    if (basicPropertiesConfig.expiration < -1) {
       LOG.error("Invalid Configuration value for AMQP Basic Properties Expiration", basicPropertiesConfig.expiration);
       issues.add(context.createConfigIssue(
           Groups.RABBITMQ.name(),
@@ -149,7 +149,12 @@ public final class RabbitUtil {
       ));
       return;
     }
-    builder.expiration(String.valueOf(basicPropertiesConfig.expiration));
+    
+    // Add Expiration Config only if was changed from -1 
+    if (basicPropertiesConfig.expiration >= 0) {
+          builder.expiration(String.valueOf(basicPropertiesConfig.expiration));
+    }
+
 
     if (basicPropertiesConfig.headers != null && !basicPropertiesConfig.headers.isEmpty()) {
       builder.headers(basicPropertiesConfig.headers);

--- a/rabbitmq-lib/src/main/java/com/streamsets/pipeline/stage/destination/rabbitmq/BasicPropertiesConfig.java
+++ b/rabbitmq-lib/src/main/java/com/streamsets/pipeline/stage/destination/rabbitmq/BasicPropertiesConfig.java
@@ -129,7 +129,7 @@ public class BasicPropertiesConfig {
   @ConfigDef(
       required = false,
       type = ConfigDef.Type.NUMBER,
-      defaultValue = "0",
+      defaultValue = "-1",
       label = "Expiration",
       description = "Expiration Time",
       displayPosition = 130,
@@ -137,7 +137,7 @@ public class BasicPropertiesConfig {
       triggeredByValue = "true",
       group = "#0"
   )
-  public short expiration = 0;
+  public long expiration = -1;
 
   @ConfigDef(
       required = false,


### PR DESCRIPTION
change expiration datatype to long,
changed default value to -1 (don't add expiration to message), 
0 Expiration creates auto discarded messages in the queue, 
if no consumers exists listening to the queue