### PR TITLE
SDC-8371 - RabbitMQ Destination, Expiration Issue & SDC-8470 - S3 Destination - Adding canned ACL support

### DIFF
--- a/aws-lib/src/main/java/com/streamsets/pipeline/stage/destination/s3/CannedACLChooserValues.java
+++ b/aws-lib/src/main/java/com/streamsets/pipeline/stage/destination/s3/CannedACLChooserValues.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2017 StreamSets Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.streamsets.pipeline.stage.destination.s3;
+
+import com.streamsets.pipeline.api.base.BaseEnumChooserValues;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+
+public class CannedACLChooserValues extends BaseEnumChooserValues<CannedAccessControlList> {
+  public CannedACLChooserValues() {
+    super(
+            CannedAccessControlList.AuthenticatedRead,
+            CannedAccessControlList.BucketOwnerRead,
+            CannedAccessControlList.BucketOwnerFullControl,
+            CannedAccessControlList.Private,
+            CannedAccessControlList.PublicRead,
+            CannedAccessControlList.PublicReadWrite
+    );
+  }
+}

--- a/aws-lib/src/main/java/com/streamsets/pipeline/stage/destination/s3/FileHelper.java
+++ b/aws-lib/src/main/java/com/streamsets/pipeline/stage/destination/s3/FileHelper.java
@@ -59,7 +59,11 @@ abstract class FileHelper {
   abstract List<UploadMetadata> handle(Iterator<Record> recordIterator, String bucket, String keyPrefix) throws IOException, StageException;
 
   protected ObjectMetadata getObjectMetadata() throws StageException {
-    ObjectMetadata metadata = null;
+    ObjectMetadata metadata = new ObjectMetadata();
+    metadata.setHeader(
+            Headers.S3_CANNED_ACL,
+            s3TargetConfigBean.cannedACL.toString()
+    );
     if (s3TargetConfigBean.sseConfig.useSSE) {
       metadata = new ObjectMetadata();
       switch (s3TargetConfigBean.sseConfig.encryption) {

--- a/aws-lib/src/main/java/com/streamsets/pipeline/stage/destination/s3/S3TargetConfigBean.java
+++ b/aws-lib/src/main/java/com/streamsets/pipeline/stage/destination/s3/S3TargetConfigBean.java
@@ -30,6 +30,7 @@ import com.streamsets.pipeline.stage.lib.aws.ProxyConfig;
 import com.streamsets.pipeline.stage.lib.aws.TransferManagerConfig;
 
 import java.util.List;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
 
 public class S3TargetConfigBean {
 
@@ -133,6 +134,18 @@ public class S3TargetConfigBean {
     triggeredByValue = {"TEXT", "JSON", "DELIMITED", "AVRO", "BINARY", "PROTOBUF", "SDC_JSON"}
   )
   public boolean compress;
+
+  @ConfigDef(
+          required = true,
+          type = ConfigDef.Type.MODEL,
+          description = "Amazon S3 set of predefined grants for objects (x-amz-acl header)",
+          label = "S3 canned ACL",
+          defaultValue = "Private",
+          displayPosition = 240,
+          group = "S3"
+  )
+  @ValueChooserModel(CannedACLChooserValues.class)
+  public CannedAccessControlList cannedACL = CannedAccessControlList.Private;
 
   @ConfigDefBean(groups = {"S3"})
   public DataGeneratorFormatConfig dataGeneratorFormatConfig;

--- a/rabbitmq-lib/src/main/java/com/streamsets/pipeline/lib/rabbitmq/common/RabbitUtil.java
+++ b/rabbitmq-lib/src/main/java/com/streamsets/pipeline/lib/rabbitmq/common/RabbitUtil.java
@@ -149,7 +149,11 @@ public final class RabbitUtil {
       ));
       return;
     }
-    builder.expiration(String.valueOf(basicPropertiesConfig.expiration));
+    
+	// add expiration only if configured to be sent
+    if (basicPropertiesConfig.setExpiration) {
+          builder.expiration(String.valueOf(basicPropertiesConfig.expiration));
+    }
 
     if (basicPropertiesConfig.headers != null && !basicPropertiesConfig.headers.isEmpty()) {
       builder.headers(basicPropertiesConfig.headers);

--- a/rabbitmq-lib/src/main/java/com/streamsets/pipeline/stage/destination/rabbitmq/BasicPropertiesConfig.java
+++ b/rabbitmq-lib/src/main/java/com/streamsets/pipeline/stage/destination/rabbitmq/BasicPropertiesConfig.java
@@ -127,17 +127,30 @@ public class BasicPropertiesConfig {
   public String replyTo;
 
   @ConfigDef(
+          required = false,
+          type = ConfigDef.Type.BOOLEAN,
+          defaultValue = "true",
+          label = "Set Expiration",
+          description = "Add Expiration Value to Message Properties",
+          displayPosition = 130,
+          dependsOn = "setAMQPMessageProperties",
+          triggeredByValue = "true",
+          group = "#0"
+  )
+  public boolean setExpiration = true;
+
+  @ConfigDef(
       required = false,
       type = ConfigDef.Type.NUMBER,
       defaultValue = "0",
       label = "Expiration",
       description = "Expiration Time",
-      displayPosition = 130,
-      dependsOn = "setAMQPMessageProperties",
+      displayPosition = 140,
+      dependsOn = "setExpiration",
       triggeredByValue = "true",
       group = "#0"
   )
-  public short expiration = 0;
+  public long expiration = 0;
 
   @ConfigDef(
       required = false,
@@ -145,7 +158,7 @@ public class BasicPropertiesConfig {
       defaultValue = "",
       label = "Message Id",
       description = "Message Id",
-      displayPosition = 140,
+      displayPosition = 150,
       dependsOn = "setAMQPMessageProperties",
       triggeredByValue = "true",
       group = "#0"
@@ -158,7 +171,7 @@ public class BasicPropertiesConfig {
       defaultValue = "true",
       label = "Set Current Time",
       description = "Set Current Time Stamp",
-      displayPosition = 150,
+      displayPosition = 160,
       dependsOn = "setAMQPMessageProperties",
       triggeredByValue = "true",
       group = "#0"
@@ -171,7 +184,7 @@ public class BasicPropertiesConfig {
       defaultValue = "",
       label = "Time Stamp",
       description = "Time Stamp",
-      displayPosition = 160,
+      displayPosition = 170,
       group = "#0",
       dependsOn = "setCurrentTime",
       triggeredByValue = "false"
@@ -184,7 +197,7 @@ public class BasicPropertiesConfig {
       defaultValue = "",
       label = "Message Type",
       description = "Message Type",
-      displayPosition = 170,
+      displayPosition = 180,
       dependsOn = "setAMQPMessageProperties",
       triggeredByValue = "true",
       group = "#0"
@@ -197,7 +210,7 @@ public class BasicPropertiesConfig {
       defaultValue = "",
       label = "User Id",
       description = "Optional user ID. Verified by RabbitMQ against the actual connection username.",
-      displayPosition = 180,
+      displayPosition = 190,
       dependsOn = "setAMQPMessageProperties",
       triggeredByValue = "true",
       group = "#0"
@@ -210,7 +223,7 @@ public class BasicPropertiesConfig {
       defaultValue = "",
       label = "App Id",
       description = "Identifier of the application that produced the message.",
-      displayPosition = 190,
+      displayPosition = 200,
       dependsOn = "setAMQPMessageProperties",
       triggeredByValue = "true",
       group = "#0"
@@ -220,3 +233,4 @@ public class BasicPropertiesConfig {
   //Cluster Id is deprecated. No need to add it.
 
 }
+


### PR DESCRIPTION
add flag (SetExpiration) to control adding the expiration property to the AMQPMessageProperties,
changed expiration data type to long from short, as it is in milliseconds.
for SDC-8371