### PR TITLE
SDC 8553 Allow Time EL for 'Resource URL' in HTTP processor

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -76,6 +76,20 @@ For Data Collector CLI, execute:
 
 To skip the RAT report during the build use the `-DskipRat` option.
 
+## Running integration tests
+
+From within the Data Collector directory, execute:
+
+`mvn install -Pdist -DskipTests`
+
+Once the dependencies are installed, run the integration tests:
+
+`mvn failsafe:integration-test -DfailIfNoTests=false`
+
+In case you want to run a specific integration class (here the module basic-lib is executed with integration tests in 'HttpProcessorIT'):
+
+`mvn -pl basic-lib failsafe:integration-test -Dit.test="HttpProcessorIT" -DfailIfNoTests=false`
+
 ## Release build
 
 From within the Data Collector directory, execute:

--- a/basic-lib/src/main/java/com/streamsets/pipeline/lib/http/HttpClientCommon.java
+++ b/basic-lib/src/main/java/com/streamsets/pipeline/lib/http/HttpClientCommon.java
@@ -23,6 +23,8 @@ import com.streamsets.pipeline.api.el.ELEvalException;
 import com.streamsets.pipeline.api.el.ELVars;
 import com.streamsets.pipeline.api.impl.Utils;
 import com.streamsets.pipeline.lib.el.RecordEL;
+import com.streamsets.pipeline.lib.el.TimeEL;
+import com.streamsets.pipeline.lib.el.TimeNowEL;
 import com.streamsets.pipeline.lib.el.VaultEL;
 import com.streamsets.pipeline.lib.util.ExceptionUtils;
 import org.glassfish.jersey.client.ClientConfig;
@@ -44,6 +46,8 @@ import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
@@ -359,6 +363,9 @@ public class HttpClientCommon {
 
   public String getResolvedUrl(String resourceUrl, Record record) throws ELEvalException {
     RecordEL.setRecordInContext(resourceVars, record);
+    TimeEL.setCalendarInContext(resourceVars, Calendar.getInstance());
+    TimeNowEL.setTimeNowInContext(resourceVars, new Date());
+
     return resourceEval.eval(resourceVars, resourceUrl, String.class);
   }
   public void destroy() {

--- a/basic-lib/src/main/java/com/streamsets/pipeline/stage/processor/http/HttpProcessorConfig.java
+++ b/basic-lib/src/main/java/com/streamsets/pipeline/stage/processor/http/HttpProcessorConfig.java
@@ -15,6 +15,8 @@
  */
 package com.streamsets.pipeline.stage.processor.http;
 
+import com.streamsets.pipeline.lib.el.TimeEL;
+import com.streamsets.pipeline.lib.el.TimeNowEL;
 import com.streamsets.pipeline.lib.el.VaultEL;
 import com.streamsets.pipeline.api.ConfigDef;
 import com.streamsets.pipeline.api.ConfigDefBean;
@@ -105,7 +107,7 @@ public class HttpProcessorConfig {
       type = ConfigDef.Type.STRING,
       label = "Resource URL",
       description = "The HTTP resource URL",
-      elDefs = RecordEL.class,
+      elDefs = {RecordEL.class, TimeEL.class, TimeNowEL.class},
       evaluation = ConfigDef.Evaluation.EXPLICIT,
       displayPosition = 60,
       group = "HTTP"


### PR DESCRIPTION
This commit is for the improvement feature requested on https://issues.streamsets.com/browse/SDC-8553.