### PR TITLE
SDC-9109 Add RUNNING_ERROR Pipeline State

### DIFF
--- a/container/src/main/java/com/streamsets/datacollector/config/PipelineState.java
+++ b/container/src/main/java/com/streamsets/datacollector/config/PipelineState.java
@@ -25,6 +25,7 @@ public enum PipelineState implements Label, Serializable {
   RUNNING("Running"),
   START_ERROR("Start Error"),
   RUN_ERROR("Run Error"),
+  RUNNING_ERROR("Running Error"),
   STOPPED("Stopped"),
   FINISHED("Finished"),
   DISCONNECTED("Disconnected"),


### PR DESCRIPTION
Added to allow for notifications on a RUNNING_ERROR state.