### PR TITLE
SDC-9202 Allow Oracle CDC recovery option when missing LogFile

### DIFF
--- a/jdbc-lib/src/main/java/com/streamsets/pipeline/stage/origin/jdbc/cdc/oracle/OracleCDCConfigBean.java
+++ b/jdbc-lib/src/main/java/com/streamsets/pipeline/stage/origin/jdbc/cdc/oracle/OracleCDCConfigBean.java
@@ -55,9 +55,10 @@ public class OracleCDCConfigBean {
   @ConfigDef(
       required = true,
       type = ConfigDef.Type.BOOLEAN,
-      label = "Missing Log File Recovery",
-      description = "If the log file is removed for the current window, reset to the first available, rather than throwing error",
-      displayPosition = 180,
+      label = "Attempt missing log file recovery",
+      description = "If the log file is removed for the current window, attempt recovery by resetting the offset to " +
+          "the first available time/SCN",
+      displayPosition = 45,
       group = "CDC",
       defaultValue = "false"
   )

--- a/jdbc-lib/src/main/java/com/streamsets/pipeline/stage/origin/jdbc/cdc/oracle/OracleCDCConfigBean.java
+++ b/jdbc-lib/src/main/java/com/streamsets/pipeline/stage/origin/jdbc/cdc/oracle/OracleCDCConfigBean.java
@@ -57,7 +57,7 @@ public class OracleCDCConfigBean {
       type = ConfigDef.Type.BOOLEAN,
       label = "Attempt missing log file recovery",
       description = "If the log file is removed for the current window, attempt recovery by resetting the offset to " +
-          "the first available time/SCN",
+          "the first available time/SCN of the CURRENT redo log.",
       displayPosition = 45,
       group = "CDC",
       defaultValue = "false"

--- a/jdbc-lib/src/main/java/com/streamsets/pipeline/stage/origin/jdbc/cdc/oracle/OracleCDCConfigBean.java
+++ b/jdbc-lib/src/main/java/com/streamsets/pipeline/stage/origin/jdbc/cdc/oracle/OracleCDCConfigBean.java
@@ -54,6 +54,17 @@ public class OracleCDCConfigBean {
 
   @ConfigDef(
       required = true,
+      type = ConfigDef.Type.BOOLEAN,
+      label = "Missing Log File Recovery",
+      description = "If the log file is removed for the current window, reset to the first available, rather than throwing error",
+      displayPosition = 180,
+      group = "CDC",
+      defaultValue = "false"
+  )
+  public boolean logFileRecovery;
+
+  @ConfigDef(
+      required = true,
       type = ConfigDef.Type.STRING,
       label = "Start Date",
       description = "Datetime to use for the initial change. Use the following format: DD-MM-YYYY HH24:MM:SS.",

--- a/jdbc-lib/src/main/java/com/streamsets/pipeline/stage/origin/jdbc/cdc/oracle/OracleCDCDSource.java
+++ b/jdbc-lib/src/main/java/com/streamsets/pipeline/stage/origin/jdbc/cdc/oracle/OracleCDCDSource.java
@@ -25,7 +25,7 @@ import com.streamsets.pipeline.api.base.configurablestage.DSource;
 import com.streamsets.pipeline.lib.jdbc.HikariPoolConfigBean;
 
 @StageDef(
-    version = 9,
+    version = 10,
     label = "Oracle CDC Client",
     description = "Origin that an read change events from an Oracle Database",
     icon = "rdbms.png",

--- a/jdbc-lib/src/main/java/com/streamsets/pipeline/stage/origin/jdbc/cdc/oracle/OracleCDCSource.java
+++ b/jdbc-lib/src/main/java/com/streamsets/pipeline/stage/origin/jdbc/cdc/oracle/OracleCDCSource.java
@@ -326,6 +326,7 @@ public class OracleCDCSource extends BaseSource {
             throw new StageException(JDBC_86,ex);
           } else {
             offset = firstAvailable;
+            continue;
           }
         }
         LOG.error("Error while attempting to produce records", ex);

--- a/jdbc-lib/src/main/java/com/streamsets/pipeline/stage/origin/jdbc/cdc/oracle/OracleCDCSource.java
+++ b/jdbc-lib/src/main/java/com/streamsets/pipeline/stage/origin/jdbc/cdc/oracle/OracleCDCSource.java
@@ -317,11 +317,10 @@ public class OracleCDCSource extends BaseSource {
         if (getContext().isPreview() && ex instanceof SQLException) {
           LOG.warn("Exception while previewing", ex);
           return NULL;
-        }
-        else if(ex instanceof SQLException && configBean.logFileRecovery) {
+        } else if (ex instanceof SQLException && configBean.logFileRecovery) {
           LOG.info("Attempting to reset to first valid offset");
           String firstAvailable = resetCDCToFirstAvailable();
-          if(offset.equalsIgnoreCase(firstAvailable)) {
+          if (offset.equalsIgnoreCase(firstAvailable)) {
             LOG.error("No valid redo log available");
             throw new StageException(JDBC_86,ex);
           } else {
@@ -371,7 +370,7 @@ public class OracleCDCSource extends BaseSource {
   private void startGeneratorThread(String lastSourceOffset) throws StageException, SQLException {
     Offset offset = null;
     LocalDateTime startTimestamp;
-    try{
+    try {
       startLogMnrForRedoDict();
       if (!StringUtils.isEmpty(lastSourceOffset)) {
         offset = new Offset(lastSourceOffset);
@@ -411,9 +410,8 @@ public class OracleCDCSource extends BaseSource {
     } catch (SQLException ex) {
       //If the exception is due to a missing log file, bubble it up so possible
       //recovery could be attempted.
-      if(ex.getErrorCode() == MISSING_LOG_FILE || ex.getErrorCode() == NO_LOG_FOUND)
-      {
-        throw new SQLException(ex);
+      if(ex.getErrorCode() == MISSING_LOG_FILE || ex.getErrorCode() == NO_LOG_FOUND) {
+        throw ex;
       }
       LOG.error("SQLException while trying to setup record generator thread", ex);
       generationStarted = false;
@@ -431,9 +429,7 @@ public class OracleCDCSource extends BaseSource {
     });
   }
 
-  private String resetCDCToFirstAvailable()
-  {
-
+  private String resetCDCToFirstAvailable() {
     Offset offset = null;
     try(PreparedStatement ps = connection.prepareStatement(GET_EARLIEST_AVAILABLE_OFFSET);
         ResultSet rs = ps.executeQuery()) {
@@ -449,7 +445,6 @@ public class OracleCDCSource extends BaseSource {
     }
     return offset == null ? "" : offset.toString();
   }
-
 
   @NotNull
   private LocalDateTime adjustStartTimeAndStartLogMnr(LocalDateTime startDate) throws SQLException, StageException {

--- a/jdbc-lib/src/main/java/com/streamsets/pipeline/stage/origin/jdbc/cdc/oracle/OracleCDCSource.java
+++ b/jdbc-lib/src/main/java/com/streamsets/pipeline/stage/origin/jdbc/cdc/oracle/OracleCDCSource.java
@@ -424,10 +424,8 @@ public class OracleCDCSource extends BaseSource {
 
     Offset offset = null;
     try(PreparedStatement ps = connection.prepareStatement(GET_EARLIEST_AVAILABLE_OFFSET);
-        ResultSet rs = ps.executeQuery())
-    {
-      if(rs.next())
-      {
+        ResultSet rs = ps.executeQuery()) {
+      if(rs.next()) {
         Timestamp t = rs.getTimestamp("FIRST_TIME");
         BigDecimal firstSCN = rs.getBigDecimal("FIRST_CHANGE");
         offset = new Offset(version, t.toLocalDateTime(), firstSCN.toPlainString(), 0);

--- a/jdbc-lib/src/main/java/com/streamsets/pipeline/stage/origin/jdbc/cdc/oracle/OracleCDCSource.java
+++ b/jdbc-lib/src/main/java/com/streamsets/pipeline/stage/origin/jdbc/cdc/oracle/OracleCDCSource.java
@@ -195,6 +195,7 @@ public class OracleCDCSource extends BaseSource {
 
   private PreparedStatement selectFromLogMnrContents;
   private static final int MISSING_LOG_FILE = 1291;
+  private static final int NO_LOG_FOUND = 1292;
   private static final int QUERY_TIMEOUT = 1013;
 
   private final Lock bufferedRecordsLock = new ReentrantLock();
@@ -317,15 +318,13 @@ public class OracleCDCSource extends BaseSource {
           LOG.warn("Exception while previewing", ex);
           return NULL;
         }
-        else if(ex instanceof SQLException && ((SQLException)ex).getErrorCode() == MISSING_LOG_FILE && configBean.logFileRecovery)
-        {
+        else if(ex instanceof SQLException && configBean.logFileRecovery) {
           LOG.info("Attempting to reset to first valid offset");
           String firstAvailable = resetCDCToFirstAvailable();
           if(offset.equalsIgnoreCase(firstAvailable)) {
             LOG.error("No valid redo log available");
             throw new StageException(JDBC_86,ex);
-          }
-          else {
+          } else {
             offset = firstAvailable;
           }
         }
@@ -371,41 +370,53 @@ public class OracleCDCSource extends BaseSource {
   private void startGeneratorThread(String lastSourceOffset) throws StageException, SQLException {
     Offset offset = null;
     LocalDateTime startTimestamp;
-    startLogMnrForRedoDict();
-    if (!StringUtils.isEmpty(lastSourceOffset)) {
-      offset = new Offset(lastSourceOffset);
-      if (lastSourceOffset.startsWith("v3")) {
-        if (!useLocalBuffering) {
-          throw new StageException(JDBC_82);
-        }
-        startTimestamp = offset.timestamp.minusSeconds(configBean.txnWindow);
-      } else {
-        if (useLocalBuffering) {
-          throw new StageException(JDBC_83);
-        }
-        startTimestamp = getDateForSCN(new BigDecimal(offset.scn));
-        offset.timestamp = startTimestamp;
-      }
-      adjustStartTimeAndStartLogMnr(startTimestamp);
-    } else { // reset the start date only if it not set.
-      if (configBean.startValue != StartValues.SCN) {
-        LocalDateTime startDate;
-        if (configBean.startValue == StartValues.DATE) {
-          startDate = LocalDateTime.parse(configBean.startDate, dateTimeColumnHandler.dateFormatter);
+    try{
+      startLogMnrForRedoDict();
+      if (!StringUtils.isEmpty(lastSourceOffset)) {
+        offset = new Offset(lastSourceOffset);
+        if (lastSourceOffset.startsWith("v3")) {
+          if (!useLocalBuffering) {
+            throw new StageException(JDBC_82);
+          }
+          startTimestamp = offset.timestamp.minusSeconds(configBean.txnWindow);
         } else {
-          startDate = nowAtDBTz();
+          if (useLocalBuffering) {
+            throw new StageException(JDBC_83);
+          }
+          startTimestamp = getDateForSCN(new BigDecimal(offset.scn));
+          offset.timestamp = startTimestamp;
         }
-        startDate = adjustStartTimeAndStartLogMnr(startDate);
-        offset = new Offset(version, startDate, ZERO, 0);
-      } else {
-        BigDecimal startCommitSCN = new BigDecimal(configBean.startSCN);
-        startLogMnrSCNToDate.setBigDecimal(1, startCommitSCN);
-        final LocalDateTime start = getDateForSCN(startCommitSCN);
-        LocalDateTime endTime = getEndTimeForStartTime(start);
-        startLogMnrSCNToDate.setString(2, endTime.format(dateTimeColumnHandler.dateFormatter));
-        startLogMnrSCNToDate.execute();
-        offset = new Offset(version, start, startCommitSCN.toPlainString(), 0);
+        adjustStartTimeAndStartLogMnr(startTimestamp);
+      } else { // reset the start date only if it not set.
+        if (configBean.startValue != StartValues.SCN) {
+          LocalDateTime startDate;
+          if (configBean.startValue == StartValues.DATE) {
+            startDate = LocalDateTime.parse(configBean.startDate, dateTimeColumnHandler.dateFormatter);
+          } else {
+            startDate = nowAtDBTz();
+          }
+          startDate = adjustStartTimeAndStartLogMnr(startDate);
+          offset = new Offset(version, startDate, ZERO, 0);
+        } else {
+          BigDecimal startCommitSCN = new BigDecimal(configBean.startSCN);
+          startLogMnrSCNToDate.setBigDecimal(1, startCommitSCN);
+          final LocalDateTime start = getDateForSCN(startCommitSCN);
+          LocalDateTime endTime = getEndTimeForStartTime(start);
+          startLogMnrSCNToDate.setString(2, endTime.format(dateTimeColumnHandler.dateFormatter));
+          startLogMnrSCNToDate.execute();
+          offset = new Offset(version, start, startCommitSCN.toPlainString(), 0);
+        }
       }
+    } catch (SQLException ex) {
+      //If the exception is due to a missing log file, bubble it up so possible
+      //recovery could be attempted.
+      if(ex.getErrorCode() == MISSING_LOG_FILE || ex.getErrorCode() == NO_LOG_FOUND)
+      {
+        throw new SQLException(ex);
+      }
+      LOG.error("SQLException while trying to setup record generator thread", ex);
+      generationStarted = false;
+      return;
     }
     final Offset os = offset;
     final PreparedStatement select = selectFromLogMnrContents;

--- a/jdbc-lib/src/main/java/com/streamsets/pipeline/stage/origin/jdbc/cdc/oracle/OracleCDCSource.java
+++ b/jdbc-lib/src/main/java/com/streamsets/pipeline/stage/origin/jdbc/cdc/oracle/OracleCDCSource.java
@@ -95,6 +95,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static com.streamsets.pipeline.lib.jdbc.JdbcErrors.JDBC_00;
+import static com.streamsets.pipeline.lib.jdbc.JdbcErrors.JDBC_02;
 import static com.streamsets.pipeline.lib.jdbc.JdbcErrors.JDBC_16;
 import static com.streamsets.pipeline.lib.jdbc.JdbcErrors.JDBC_40;
 import static com.streamsets.pipeline.lib.jdbc.JdbcErrors.JDBC_404;
@@ -224,6 +225,7 @@ public class OracleCDCSource extends BaseSource {
     UNKNOWN
   }
 
+  private static final String GET_EARLIEST_AVAILABLE_OFFSET = "SELECT min(FIRST_TIME) as FIRST_TIME, min(FIRST_CHANGE#) as FIRST_CHANGE FROM V$LOG where STATUS = 'CURRENT'";
   private static final String GET_TIMESTAMPS_FROM_LOGMNR_CONTENTS = "SELECT TIMESTAMP FROM V$LOGMNR_CONTENTS ORDER BY TIMESTAMP";
   private static final String OFFSET_DELIM = "::";
   private static final int RESULTSET_CLOSED_AS_LOGMINER_SESSION_CLOSED = 1306;
@@ -291,6 +293,7 @@ public class OracleCDCSource extends BaseSource {
     int recordGenerationAttempts = 0;
     boolean recordsProduced = false;
     String nextOffset = StringUtils.trimToEmpty(lastSourceOffset);
+    String offset = lastSourceOffset;
     pollForStageExceptions();
     while (!getContext().isStopped() && !recordsProduced && recordGenerationAttempts++ < MAX_RECORD_GENERATION_ATTEMPTS) {
       if (!sentInitialSchemaEvent) {
@@ -303,7 +306,7 @@ public class OracleCDCSource extends BaseSource {
 
       try {
         if (!generationStarted) {
-          startGeneratorThread(lastSourceOffset);
+          startGeneratorThread(offset);
         }
       } catch (StageException ex) {
         LOG.error("Error while attempting to produce records", ex);
@@ -313,6 +316,18 @@ public class OracleCDCSource extends BaseSource {
         if (getContext().isPreview() && ex instanceof SQLException) {
           LOG.warn("Exception while previewing", ex);
           return NULL;
+        }
+        else if(ex instanceof SQLException && ((SQLException)ex).getErrorCode() == MISSING_LOG_FILE && configBean.logFileRecovery)
+        {
+          LOG.info("Attempting to reset to first valid offset");
+          String firstAvailable = resetCDCToFirstAvailable();
+          if(offset.equalsIgnoreCase(firstAvailable)) {
+            LOG.error("No valid redo log available");
+            throw new StageException(JDBC_86,ex);
+          }
+          else {
+            offset = firstAvailable;
+          }
         }
         LOG.error("Error while attempting to produce records", ex);
         errorRecordHandler.onError(JDBC_44, Throwables.getStackTraceAsString(ex));
@@ -356,47 +371,41 @@ public class OracleCDCSource extends BaseSource {
   private void startGeneratorThread(String lastSourceOffset) throws StageException, SQLException {
     Offset offset = null;
     LocalDateTime startTimestamp;
-    try {
-      startLogMnrForRedoDict();
-      if (!StringUtils.isEmpty(lastSourceOffset)) {
-        offset = new Offset(lastSourceOffset);
-        if (lastSourceOffset.startsWith("v3")) {
-          if (!useLocalBuffering) {
-            throw new StageException(JDBC_82);
-          }
-          startTimestamp = offset.timestamp.minusSeconds(configBean.txnWindow);
-        } else {
-          if (useLocalBuffering) {
-            throw new StageException(JDBC_83);
-          }
-          startTimestamp = getDateForSCN(new BigDecimal(offset.scn));
-          offset.timestamp = startTimestamp;
+    startLogMnrForRedoDict();
+    if (!StringUtils.isEmpty(lastSourceOffset)) {
+      offset = new Offset(lastSourceOffset);
+      if (lastSourceOffset.startsWith("v3")) {
+        if (!useLocalBuffering) {
+          throw new StageException(JDBC_82);
         }
-        adjustStartTimeAndStartLogMnr(startTimestamp);
-      } else { // reset the start date only if it not set.
-        if (configBean.startValue != StartValues.SCN) {
-          LocalDateTime startDate;
-          if (configBean.startValue == StartValues.DATE) {
-            startDate = LocalDateTime.parse(configBean.startDate, dateTimeColumnHandler.dateFormatter);
-          } else {
-            startDate = nowAtDBTz();
-          }
-          startDate = adjustStartTimeAndStartLogMnr(startDate);
-          offset = new Offset(version, startDate, ZERO, 0);
-        } else {
-          BigDecimal startCommitSCN = new BigDecimal(configBean.startSCN);
-          startLogMnrSCNToDate.setBigDecimal(1, startCommitSCN);
-          final LocalDateTime start = getDateForSCN(startCommitSCN);
-          LocalDateTime endTime = getEndTimeForStartTime(start);
-          startLogMnrSCNToDate.setString(2, endTime.format(dateTimeColumnHandler.dateFormatter));
-          startLogMnrSCNToDate.execute();
-          offset = new Offset(version, start, startCommitSCN.toPlainString(), 0);
+        startTimestamp = offset.timestamp.minusSeconds(configBean.txnWindow);
+      } else {
+        if (useLocalBuffering) {
+          throw new StageException(JDBC_83);
         }
+        startTimestamp = getDateForSCN(new BigDecimal(offset.scn));
+        offset.timestamp = startTimestamp;
       }
-    } catch (SQLException ex) {
-      LOG.error("SQLException while trying to setup record generator thread", ex);
-      generationStarted = false;
-      return;
+      adjustStartTimeAndStartLogMnr(startTimestamp);
+    } else { // reset the start date only if it not set.
+      if (configBean.startValue != StartValues.SCN) {
+        LocalDateTime startDate;
+        if (configBean.startValue == StartValues.DATE) {
+          startDate = LocalDateTime.parse(configBean.startDate, dateTimeColumnHandler.dateFormatter);
+        } else {
+          startDate = nowAtDBTz();
+        }
+        startDate = adjustStartTimeAndStartLogMnr(startDate);
+        offset = new Offset(version, startDate, ZERO, 0);
+      } else {
+        BigDecimal startCommitSCN = new BigDecimal(configBean.startSCN);
+        startLogMnrSCNToDate.setBigDecimal(1, startCommitSCN);
+        final LocalDateTime start = getDateForSCN(startCommitSCN);
+        LocalDateTime endTime = getEndTimeForStartTime(start);
+        startLogMnrSCNToDate.setString(2, endTime.format(dateTimeColumnHandler.dateFormatter));
+        startLogMnrSCNToDate.execute();
+        offset = new Offset(version, start, startCommitSCN.toPlainString(), 0);
+      }
     }
     final Offset os = offset;
     final PreparedStatement select = selectFromLogMnrContents;
@@ -409,6 +418,28 @@ public class OracleCDCSource extends BaseSource {
       }
     });
   }
+
+  private String resetCDCToFirstAvailable()
+  {
+
+    Offset offset = null;
+    try(PreparedStatement ps = connection.prepareStatement(GET_EARLIEST_AVAILABLE_OFFSET);
+        ResultSet rs = ps.executeQuery())
+    {
+      if(rs.next())
+      {
+        Timestamp t = rs.getTimestamp("FIRST_TIME");
+        BigDecimal firstSCN = rs.getBigDecimal("FIRST_CHANGE");
+        offset = new Offset(version, t.toLocalDateTime(), firstSCN.toPlainString(), 0);
+      }
+    }
+    catch(SQLException ex){
+      LOG.warn("Could not determine oldest available redo log time");
+      addToStageExceptionsQueue(new StageException(JDBC_02, ex));
+    }
+    return offset == null ? "" : offset.toString();
+  }
+
 
   @NotNull
   private LocalDateTime adjustStartTimeAndStartLogMnr(LocalDateTime startDate) throws SQLException, StageException {

--- a/jdbc-lib/src/main/java/com/streamsets/pipeline/stage/origin/jdbc/cdc/oracle/OracleCDCSourceUpgrader.java
+++ b/jdbc-lib/src/main/java/com/streamsets/pipeline/stage/origin/jdbc/cdc/oracle/OracleCDCSourceUpgrader.java
@@ -79,7 +79,13 @@ public class OracleCDCSourceUpgrader implements StageUpgrader {
         }
         // fall through
       case 8:
-        return upgradeV8ToV9(configs);
+        configs = upgradeV8ToV9(configs);
+        if(toVersion == 9){
+          return configs;
+        }
+        // fall through
+      case 9:
+        return upgradeV9ToV10(configs);
 
       default:
         throw new IllegalStateException(Utils.format("Unexpected fromVersion {}", fromVersion));
@@ -171,5 +177,10 @@ public class OracleCDCSourceUpgrader implements StageUpgrader {
     return configs.parallelStream()
         .filter(config -> !config.getName().equals("oracleCDCConfigBean.queryTimeout"))
         .collect(Collectors.toList());
+  }
+
+  private static List<Config> upgradeV9ToV10(List<Config> configs) {
+    configs.add(new Config("oracleCDCConfigBean.logFileRecovery", false));
+    return configs;
   }
 }


### PR DESCRIPTION
The purpose of this Pull Request is to allow the Oracle CDC Client to "recover" in the event a log file goes missing.  

Specifically, in my use case, our RDS rolls its log file over every 5 minutes.  Therefore, if I stop the pipeline to do some maintenance, and restart after the rollover window has passed, CDC generation fails. (Note, this fix also solves SDC-9006 where no StageException was being logged if LogFile was missing on startup).

This PR adds functionality to allow the plugin to find the first available current Redo Log entry and resume from that position in the event the log file for the current offset is unavailable.

I am open to other approaches to fixing this issue, but hope this can at the minimum spark discussion. 