### PR TITLE
SDC-9414. Non-Resolvable parent POM for wholefile-converter-protolib

### DIFF
--- a/wholefile-converter-protolib/pom.xml
+++ b/wholefile-converter-protolib/pom.xml
@@ -22,8 +22,9 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>com.streamsets</groupId>
-    <artifactId>streamsets-datacollector-root</artifactId>
+    <artifactId>streamsets-datacollector-root-lib</artifactId>
     <version>3.4.0-SNAPSHOT</version>
+    <relativePath>../root-lib</relativePath>
   </parent>
   <artifactId>streamsets-datacollector-wholefile-converter-protolib</artifactId>
   <version>3.4.0-SNAPSHOT</version>


### PR DESCRIPTION
Not sure if I should be using SDC-9414 since it was already closed as resolved, but please educate me on the right commit message. Prior to this change, I could not build the project due to the error referenced in that issue:

`[WARNING] 'parent.relativePath' of POM com.streamsets:streamsets-datacollector-wholefile-converter-protolib:3.4.0-SNAPSHOT (/path/to/datacollector/wholefile-converter-protolib/pom.xml) points at com.streamsets:streamsets-datacollector instead of com.streamsets:streamsets-datacollector-root, please verify your project structure @ line 23, column 11`

After this change, I am able to build it successfully.