### PR TITLE
Update CredentialStores.html to fix credential expression

### DIFF
--- a/docs/generated/datacollector/UserGuide/Configuration/CredentialStores.html
+++ b/docs/generated/datacollector/UserGuide/Configuration/CredentialStores.html
@@ -1421,7 +1421,7 @@
             delay of 1,000 milliseconds. The credential name argument uses the default ampersand
             (&amp;) as the separator. The expression allows any user belonging to the devops group
             access to the credential when validating, previewing, or running the
-            pipeline:<pre class="pre codeblock"><code>${credential:getwithOptions("vault", "devops", "/secret/databases/oracle&amp;password", "delay=1000")}</code></pre></div>
+            pipeline:<pre class="pre codeblock"><code>${credential:getWithOptions("vault", "devops", "/secret/databases/oracle&amp;password", "delay=1000")}</code></pre></div>
 
  </div>
 


### PR DESCRIPTION
Copy/pasting the vault credential:getwithOptions from the bottom of the page https://streamsets.com/documentation/datacollector/latest/help/#datacollector/UserGuide/Configuration/CredentialStores.html#concept_sbq_vps_51b had a lower case w, when it should be upper case, causing the function to fail. I have fixed this in the docs