### PR TITLE
Trivial: Fixing typos in a number of JDBC Origins

### DIFF
--- a/jdbc-lib/src/main/java/com/streamsets/pipeline/stage/origin/jdbc/CT/sqlserver/SQLServerCTDSource.java
+++ b/jdbc-lib/src/main/java/com/streamsets/pipeline/stage/origin/jdbc/CT/sqlserver/SQLServerCTDSource.java
@@ -30,7 +30,7 @@ import com.streamsets.pipeline.stage.origin.jdbc.table.TableJdbcConfigBean;
 @StageDef(
     version = 2,
     label = "SQL Server Change Tracking Client",
-    description = "Origin that an read change events from an SQL Server Database",
+    description = "Origin that can read change events from an MS SQL Server Database",
     icon = "sql-server-multithreaded.png",
     resetOffset = true,
     producesEvents = true,

--- a/jdbc-lib/src/main/java/com/streamsets/pipeline/stage/origin/jdbc/cdc/oracle/OracleCDCDSource.java
+++ b/jdbc-lib/src/main/java/com/streamsets/pipeline/stage/origin/jdbc/cdc/oracle/OracleCDCDSource.java
@@ -27,7 +27,7 @@ import com.streamsets.pipeline.lib.jdbc.HikariPoolConfigBean;
 @StageDef(
     version = 9,
     label = "Oracle CDC Client",
-    description = "Origin that an read change events from an Oracle Database",
+    description = "Origin that can read change events from an Oracle Database",
     icon = "rdbms.png",
     recordsByRef = true,
     producesEvents = true,

--- a/jdbc-lib/src/main/java/com/streamsets/pipeline/stage/origin/jdbc/cdc/postgres/PostgresCDCDSource.java
+++ b/jdbc-lib/src/main/java/com/streamsets/pipeline/stage/origin/jdbc/cdc/postgres/PostgresCDCDSource.java
@@ -28,7 +28,7 @@ import com.streamsets.pipeline.stage.origin.jdbc.cdc.postgres.Groups;
 @StageDef(
     version = 1,
     label = "PostgreSQL CDC Client",
-    description = "Origin that an read change events from a PostgreSQL Database",
+    description = "Origin that can read change events from a PostgreSQL Database",
     icon = "rdbms.png",
     recordsByRef = true,
     producesEvents = true,

--- a/jdbc-lib/src/main/java/com/streamsets/pipeline/stage/origin/jdbc/cdc/sqlserver/SQLServerCDCDSource.java
+++ b/jdbc-lib/src/main/java/com/streamsets/pipeline/stage/origin/jdbc/cdc/sqlserver/SQLServerCDCDSource.java
@@ -29,7 +29,7 @@ import com.streamsets.pipeline.stage.origin.jdbc.table.TableJdbcConfigBean;
 @StageDef(
     version = 4,
     label = "SQL Server CDC Client",
-    description = "Origin that an read change events from an MS SQL Server Database",
+    description = "Origin that can read change events from an MS SQL Server Database",
     icon = "sql-server-multithreaded.png",
     resetOffset = true,
     producesEvents = true,


### PR DESCRIPTION
The typo can noticed in the origin's tooltip for:

- MS SQL Server CDC Origin
- MS SQL Server CT Origin
- Oracle CDC Origin
- PostgreSQL CDC Origin

Also, added "MS" to the MS SQL Server CT Origin to make it consistent with the MS SQL Server CDC Origin.