### PR TITLE
Extensible offset storage, adds possibility to store pipeline offsets…

### DIFF
--- a/container/pom.xml
+++ b/container/pom.xml
@@ -439,6 +439,25 @@
       <version>0.7.2</version>
     </dependency>
 
+    <!--TODO reviewer, what versions of zookeeper,curator are compatible with sdc? there may be conflicts with other libs I'm not aware of -->
+    <dependency>
+      <groupId>org.apache.zookeeper</groupId>
+      <artifactId>zookeeper</artifactId>
+      <version>3.4.6</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.curator</groupId>
+      <artifactId>curator-framework</artifactId>
+      <version>4.0.1</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.zookeeper</groupId>
+          <artifactId>zookeeper</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
     <!-- Support bundles -->
     <dependency>
       <groupId>com.amazonaws</groupId>

--- a/container/src/main/java/com/streamsets/datacollector/execution/runner/cluster/ClusterRunner.java
+++ b/container/src/main/java/com/streamsets/datacollector/execution/runner/cluster/ClusterRunner.java
@@ -63,6 +63,7 @@ import com.streamsets.datacollector.runner.Pipeline;
 import com.streamsets.datacollector.runner.PipelineRuntimeException;
 import com.streamsets.datacollector.runner.UserContext;
 import com.streamsets.datacollector.runner.production.OffsetFileUtil;
+import com.streamsets.datacollector.runner.production.OffsetStorageFactory;
 import com.streamsets.datacollector.runner.production.SourceOffset;
 import com.streamsets.datacollector.security.SecurityConfiguration;
 import com.streamsets.datacollector.stagelibrary.StageLibraryTask;
@@ -133,6 +134,8 @@ public class ClusterRunner extends AbstractRunner {
   @Inject LineagePublisherTask lineagePublisherTask;
   @Inject SupportBundleManager supportBundleManager;
   @Inject StatsCollector statsCollector;
+  @Inject
+  OffsetStorageFactory offsetStorageFactory;
 
   private String pipelineTitle = null;
   private ObjectGraph objectGraph;
@@ -187,7 +190,8 @@ public class ClusterRunner extends AbstractRunner {
       ResourceManager resourceManager,
       EventListenerManager eventListenerManager,
       String sdcToken,
-      AclStoreTask aclStoreTask
+      AclStoreTask aclStoreTask,
+      OffsetStorageFactory offsetStorageFactory
   ) {
     super(
       name,
@@ -210,6 +214,7 @@ public class ClusterRunner extends AbstractRunner {
     this.resourceManager = resourceManager;
     this.slaveCallbackManager = new SlaveCallbackManager();
     this.slaveCallbackManager.setClusterToken(sdcToken);
+    this.offsetStorageFactory = offsetStorageFactory;
   }
 
   @SuppressWarnings("deprecation")
@@ -786,7 +791,8 @@ public class ClusterRunner extends AbstractRunner {
       null,
       blobStoreTask,
       lineagePublisherTask,
-      statsCollector
+      statsCollector,
+      offsetStorageFactory
     );
     return builder.build(new UserContext(context.getUser(),
         getRuntimeInfo().isDPMEnabled(),

--- a/container/src/main/java/com/streamsets/datacollector/execution/runner/common/ProductionPipelineBuilder.java
+++ b/container/src/main/java/com/streamsets/datacollector/execution/runner/common/ProductionPipelineBuilder.java
@@ -25,6 +25,7 @@ import com.streamsets.datacollector.runner.Pipeline;
 import com.streamsets.datacollector.runner.PipelineRuntimeException;
 import com.streamsets.datacollector.runner.SourceOffsetTracker;
 import com.streamsets.datacollector.runner.UserContext;
+import com.streamsets.datacollector.runner.production.OffsetStorageFactory;
 import com.streamsets.datacollector.runner.production.ProductionSourceOffsetCommitterOffsetTracker;
 import com.streamsets.datacollector.runner.production.ProductionSourceOffsetTracker;
 import com.streamsets.datacollector.stagelibrary.StageLibraryTask;
@@ -57,6 +58,7 @@ public class ProductionPipelineBuilder {
 
   private final ProductionPipelineRunner runner;
   private final Observer observer;
+  private final OffsetStorageFactory offsetStorageFactory;
 
   public ProductionPipelineBuilder(
       @Named("name") String name,
@@ -68,7 +70,8 @@ public class ProductionPipelineBuilder {
       Observer observer,
       BlobStoreTask blobStoreTask,
       LineagePublisherTask lineagePublisherTask,
-      StatsCollector statsCollector
+      StatsCollector statsCollector,
+      OffsetStorageFactory offsetStorageFactory
   ) {
     this.name = name;
     this.rev = rev;
@@ -80,6 +83,7 @@ public class ProductionPipelineBuilder {
     this.blobStoreTask = blobStoreTask;
     this.lineagePublisherTask = lineagePublisherTask;
     this.statsCollector = statsCollector;
+    this.offsetStorageFactory = offsetStorageFactory;
   }
 
   public ProductionPipeline build(
@@ -122,7 +126,12 @@ public class ProductionPipelineBuilder {
       sourceOffsetTracker = new ProductionSourceOffsetCommitterOffsetTracker(name, rev, runtimeInfo,
         (OffsetCommitter) pipeline.getSource());
     } else {
-      sourceOffsetTracker = new ProductionSourceOffsetTracker(name, rev, runtimeInfo);
+      sourceOffsetTracker = new ProductionSourceOffsetTracker(
+          name,
+          rev,
+          runtimeInfo,
+          offsetStorageFactory.create(configuration)
+      );
     }
     runner.setOffsetTracker(sourceOffsetTracker);
     runner.setPipelineStartTime(startTime);

--- a/container/src/main/java/com/streamsets/datacollector/execution/runner/common/dagger/PipelineProviderModule.java
+++ b/container/src/main/java/com/streamsets/datacollector/execution/runner/common/dagger/PipelineProviderModule.java
@@ -41,6 +41,7 @@ import com.streamsets.datacollector.metrics.MetricsModule;
 import com.streamsets.datacollector.runner.Observer;
 import com.streamsets.datacollector.runner.PipelineRunner;
 import com.streamsets.datacollector.runner.SourceOffsetTracker;
+import com.streamsets.datacollector.runner.production.OffsetStorageFactory;
 import com.streamsets.datacollector.runner.production.ProductionSourceOffsetTracker;
 import com.streamsets.datacollector.runner.production.RulesConfigLoaderRunnable;
 import com.streamsets.datacollector.stagelibrary.StageLibraryTask;
@@ -132,6 +133,11 @@ public class PipelineProviderModule {
   }
 
   @Provides @Singleton
+  public OffsetStorageFactory provideOffsetStorageFactory() {
+    return OffsetStorageFactory.OffsetStorageFactoryImpl.INSTANCE;
+  }
+
+  @Provides @Singleton
   public RulesConfigLoader provideRulesConfigLoader(
       @Named("name") String name,
       @Named("rev") String rev,
@@ -204,7 +210,8 @@ public class PipelineProviderModule {
     Observer observer,
     BlobStoreTask blobStoreTask,
     LineagePublisherTask lineagePublisherTask,
-    StatsCollector statsCollector
+    StatsCollector statsCollector,
+    OffsetStorageFactory offsetStorageFactory
   ) {
     return new ProductionPipelineBuilder(
       name,
@@ -216,7 +223,8 @@ public class PipelineProviderModule {
       observer,
       blobStoreTask,
       lineagePublisherTask,
-      statsCollector
+      statsCollector,
+      offsetStorageFactory
     );
   }
 

--- a/container/src/main/java/com/streamsets/datacollector/execution/runner/slave/dagger/SlaveRunnerModule.java
+++ b/container/src/main/java/com/streamsets/datacollector/execution/runner/slave/dagger/SlaveRunnerModule.java
@@ -18,9 +18,11 @@ package com.streamsets.datacollector.execution.runner.slave.dagger;
 import com.streamsets.datacollector.execution.EventListenerManager;
 import com.streamsets.datacollector.execution.Runner;
 import com.streamsets.datacollector.execution.runner.common.AsyncRunner;
+import com.streamsets.datacollector.execution.runner.common.dagger.PipelineProviderModule;
 import com.streamsets.datacollector.execution.runner.slave.SlaveStandaloneRunner;
 import com.streamsets.datacollector.execution.runner.standalone.StandaloneRunner;
 import com.streamsets.datacollector.main.RuntimeInfo;
+import com.streamsets.datacollector.runner.production.OffsetStorageFactory;
 import com.streamsets.datacollector.util.Configuration;
 import com.streamsets.pipeline.lib.executor.SafeScheduledExecutorService;
 
@@ -29,6 +31,7 @@ import dagger.ObjectGraph;
 import dagger.Provides;
 
 import javax.inject.Named;
+import javax.inject.Singleton;
 
 @Module(injects = Runner.class, library = true, complete = false)
 public class SlaveRunnerModule {
@@ -58,5 +61,10 @@ public class SlaveRunnerModule {
       @Named("runnerStopExecutor") SafeScheduledExecutorService asyncStopExecutor
   ) {
     return new AsyncRunner(runner, asyncExecutor, asyncStopExecutor);
+  }
+
+  @Provides @Singleton
+  public OffsetStorageFactory provideOffsetStorageFactory() {
+    return OffsetStorageFactory.OffsetStorageFactoryImpl.INSTANCE;
   }
 }

--- a/container/src/main/java/com/streamsets/datacollector/execution/runner/standalone/StandaloneRunner.java
+++ b/container/src/main/java/com/streamsets/datacollector/execution/runner/standalone/StandaloneRunner.java
@@ -69,10 +69,7 @@ import com.streamsets.datacollector.runner.Pipeline;
 import com.streamsets.datacollector.runner.PipelineRunner;
 import com.streamsets.datacollector.runner.PipelineRuntimeException;
 import com.streamsets.datacollector.runner.UserContext;
-import com.streamsets.datacollector.runner.production.OffsetFileUtil;
-import com.streamsets.datacollector.runner.production.ProductionSourceOffsetTracker;
-import com.streamsets.datacollector.runner.production.RulesConfigLoaderRunnable;
-import com.streamsets.datacollector.runner.production.SourceOffset;
+import com.streamsets.datacollector.runner.production.*;
 import com.streamsets.datacollector.store.PipelineInfo;
 import com.streamsets.datacollector.store.PipelineStoreException;
 import com.streamsets.datacollector.updatechecker.UpdateChecker;
@@ -140,6 +137,8 @@ public class StandaloneRunner extends AbstractRunner implements StateListener {
   @Inject SnapshotStore snapshotStore;
   @Inject @Named("runnerExecutor") SafeScheduledExecutorService runnerExecutor;
   @Inject ResourceManager resourceManager;
+  @Inject
+  OffsetStorageFactory offsetStorageFactory;
 
   private final ObjectGraph objectGraph;
   private String pipelineTitle = null;
@@ -420,7 +419,13 @@ public class StandaloneRunner extends AbstractRunner implements StateListener {
     if (RESET_OFFSET_DISALLOWED_STATUSES.contains(status)) {
       throw new PipelineRunnerException(ContainerError.CONTAINER_0104, getName());
     }
-    ProductionSourceOffsetTracker offsetTracker = new ProductionSourceOffsetTracker(getName(), getRev(), getRuntimeInfo());
+
+    ProductionSourceOffsetTracker offsetTracker = new ProductionSourceOffsetTracker(
+        getName(),
+        getRev(),
+        getRuntimeInfo(),
+        offsetStorageFactory.create(getConfiguration())
+    );
     offsetTracker.resetOffset(getName(), getRev());
   }
 

--- a/container/src/main/java/com/streamsets/datacollector/runner/production/OffsetStorage.java
+++ b/container/src/main/java/com/streamsets/datacollector/runner/production/OffsetStorage.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2017 StreamSets Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.streamsets.datacollector.runner.production;
+
+import com.google.common.base.Throwables;
+import com.streamsets.datacollector.json.ObjectMapperFactory;
+import com.streamsets.datacollector.main.RuntimeInfo;
+import com.streamsets.datacollector.restapi.bean.BeanHelper;
+import com.streamsets.datacollector.restapi.bean.SourceOffsetJson;
+import org.apache.curator.framework.CuratorFramework;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * Persistent storage for pipeline offsets.
+ */
+public interface OffsetStorage {
+  void resetOffsets(RuntimeInfo runtimeInfo, String pipelineName, String rev);
+
+  void saveOffsets(RuntimeInfo runtimeInfo, String pipelineName, String rev, Map<String, String> offset);
+
+  Map<String, String> getAndSaveIfEmpty(RuntimeInfo runtimeInfo, String pipelineName, String rev);
+
+  /**
+   * File-based storage.
+   */
+  class FileStorage implements OffsetStorage {
+    public static final String STORAGE_TYPE = "file";
+
+    @Override
+    public void resetOffsets(RuntimeInfo runtimeInfo, String pipelineName, String rev) {
+      OffsetFileUtil.resetOffsets(runtimeInfo, pipelineName, rev);
+    }
+
+    @Override
+    public void saveOffsets(RuntimeInfo runtimeInfo, String pipelineName, String rev, Map<String, String> offset) {
+      OffsetFileUtil.saveOffsets(runtimeInfo, pipelineName, rev, offset);
+    }
+
+    @Override
+    public Map<String, String> getAndSaveIfEmpty(RuntimeInfo runtimeInfo, String pipelineName, String rev) {
+      return OffsetFileUtil.saveIfEmpty(runtimeInfo, pipelineName, rev);
+    }
+  }
+
+  /**
+   * Zookeeper-based storage.
+   */
+  class ZookeeperStorage implements OffsetStorage {
+    private static final Map<String, String> DEFAULT_OFFSET = Collections.emptyMap();
+    public static final String STORAGE_TYPE = "zookeeper";
+    public static final String ADDRESS_PROPERTY = "offsets.storage.zookeeper.address";
+    public static final String PREFIX_PROPERTY = "offsets.storage.zookeeper.prefix";
+    public static final String TIMEOUT_PROPERTY = "offsets.storage.zookeeper.connect_timeout";
+    public static final String RECONNECT_PAUSE_PROPERTY = "offsets.storage.zookeeper.reconnect_pause";
+    public static final int TIMEOUT_DEFAULT = 5000;
+    public static final int RECONNECT_PAUSE_DEFAULT = 500;
+
+    private final CuratorFramework client;
+    private final String prefix;
+    private boolean nodeExits = false;
+
+    public ZookeeperStorage(CuratorFramework client, String prefix) {
+      this.client = client;
+      this.prefix = prefix;
+    }
+
+    @Override
+    public void resetOffsets(RuntimeInfo runtimeInfo, String pipelineName, String rev) {
+      saveOffsets(runtimeInfo, pipelineName, rev, DEFAULT_OFFSET);
+    }
+
+    @Override
+    public void saveOffsets(RuntimeInfo runtimeInfo, String pipelineName, String rev, Map<String, String> offset) {
+      try {
+        createNodeIfRequired(pipelineName, rev);
+        client.setData().forPath(path(pipelineName, rev), toBytes(offset));
+      } catch (Exception e) {
+        // TODO reviewer, what exception class should be used here?
+        throw Throwables.propagate(e);
+      }
+    }
+
+    @Override
+    public Map<String, String> getAndSaveIfEmpty(RuntimeInfo runtimeInfo, String pipelineName, String rev) {
+      try {
+        createNodeIfRequired(pipelineName, rev);
+        byte[] bytes = client.getData().forPath(path(pipelineName, rev));
+        return fromBytes(bytes).getOffsets();
+      } catch (Exception e) {
+        // TODO reviewer, what exception class should be used here?
+        throw Throwables.propagate(e);
+      }
+    }
+
+    @NotNull
+    private SourceOffset fromBytes(byte[] bytes) throws IOException {
+      SourceOffsetJson sourceOffsetJson = ObjectMapperFactory.get().readValue(bytes, SourceOffsetJson.class);
+      SourceOffset sourceOffset = BeanHelper.unwrapSourceOffset(sourceOffsetJson);
+      SourceOffsetUpgrader.upgrade(sourceOffset);
+      return sourceOffset;
+    }
+
+    private byte[] toBytes(Map<String, String> offsets) throws IOException {
+      SourceOffset sourceOffset = new SourceOffset(SourceOffset.CURRENT_VERSION, offsets);
+      return ObjectMapperFactory.get().writeValueAsBytes(BeanHelper.wrapSourceOffset(sourceOffset));
+    }
+
+    private synchronized void createNodeIfRequired(String pipelineName, String rev) throws Exception {
+      if (!nodeExits) {
+        String path = path(pipelineName, rev);
+        if (client.checkExists().forPath(path) == null) {
+          // create new node and save default offsets value
+          client.create().creatingParentsIfNeeded().forPath(path, toBytes(DEFAULT_OFFSET));
+        }
+        nodeExits = true;
+      }
+    }
+
+    private String path(String pipelineName, String rev) {
+      String sanitizedName = pipelineName.replaceAll("/", "_");
+      String sanitizedPrefix = prefix;
+      if (sanitizedPrefix.startsWith("/")) {
+        sanitizedPrefix = sanitizedPrefix.substring(1);
+      }
+      if (sanitizedPrefix.endsWith("/")) {
+        sanitizedPrefix = sanitizedPrefix.substring(0, sanitizedPrefix.length() - 1);
+      }
+
+      return String.format("/%s/%s/%s", sanitizedPrefix, sanitizedName, rev);
+    }
+  }
+}

--- a/container/src/main/java/com/streamsets/datacollector/runner/production/OffsetStorageFactory.java
+++ b/container/src/main/java/com/streamsets/datacollector/runner/production/OffsetStorageFactory.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2017 StreamSets Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.streamsets.datacollector.runner.production;
+
+import com.streamsets.datacollector.util.Configuration;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.retry.RetryUntilElapsed;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Factory for {@link OffsetStorage}.
+ */
+public interface OffsetStorageFactory {
+  OffsetStorageFactory FILE = new FileOffsetStorageFactory();
+
+  OffsetStorage create(Configuration configuration);
+
+  /**
+   * Creates {@link com.streamsets.datacollector.runner.production.OffsetStorage.FileStorage}.
+   */
+  class FileOffsetStorageFactory implements OffsetStorageFactory {
+    @Override
+    public OffsetStorage create(Configuration configuration) {
+      return new OffsetStorage.FileStorage();
+    }
+  }
+
+  /**
+   * Singleton factory instance. Caches zookeeper client and shares it between all zookeeper-based offset storages.
+   */
+  class OffsetStorageFactoryImpl implements OffsetStorageFactory {
+    public static final OffsetStorageFactoryImpl INSTANCE = new OffsetStorageFactoryImpl();
+
+    // cache for zookeeper clients
+    private final ConcurrentHashMap<String, CuratorFramework> zookeeperClients = new ConcurrentHashMap<>();
+
+    private OffsetStorageFactoryImpl() {
+    }
+
+    @Override
+    public OffsetStorage create(Configuration config) {
+      String storageType = config.get(
+          ProductionSourceOffsetTracker.STORAGE_TYPE,
+          OffsetStorage.FileStorage.STORAGE_TYPE
+      );
+
+      switch (storageType) {
+        case OffsetStorage.FileStorage.STORAGE_TYPE:
+          return new OffsetStorage.FileStorage();
+        case OffsetStorage.ZookeeperStorage.STORAGE_TYPE:
+          return createZookeeperStorage(config);
+        default:
+          // TODO reviewer, what exception class should be used here?
+          throw new IllegalStateException(String.format("Unknown storage type '%s'", storageType)); // TODO
+      }
+    }
+
+    private OffsetStorage.ZookeeperStorage createZookeeperStorage(Configuration config) {
+      String zookeeperAddress = config.get(OffsetStorage.ZookeeperStorage.ADDRESS_PROPERTY, "unknown");
+      // TODO reviewer, what is preferred way to handle missing config options? What exception class should be thrown?
+      if ("unknown".equals(zookeeperAddress)) {
+        throw new IllegalStateException(
+            String.format(
+                "Zookeeper address not configured, set it via '%s' sdc configuration property",
+                OffsetStorage.ZookeeperStorage.ADDRESS_PROPERTY
+            )
+        );
+      }
+
+      int timeout = config.get(OffsetStorage.ZookeeperStorage.TIMEOUT_PROPERTY, OffsetStorage.ZookeeperStorage.TIMEOUT_DEFAULT);
+      int pause = config.get(OffsetStorage.ZookeeperStorage.RECONNECT_PAUSE_PROPERTY, OffsetStorage.ZookeeperStorage.RECONNECT_PAUSE_DEFAULT);
+
+      CuratorFramework client = zookeeperClients.computeIfAbsent(zookeeperAddress, (address) -> {
+        CuratorFramework zoo = CuratorFrameworkFactory.newClient(
+            address,
+            new RetryUntilElapsed(timeout, pause)
+        );
+        zoo.start();
+        return zoo;
+      });
+
+      String prefix = config.get(OffsetStorage.ZookeeperStorage.PREFIX_PROPERTY, "");
+      return new OffsetStorage.ZookeeperStorage(client, prefix);
+    }
+  }
+}

--- a/container/src/main/java/com/streamsets/datacollector/runner/production/ProductionSourceOffsetCommitterOffsetTracker.java
+++ b/container/src/main/java/com/streamsets/datacollector/runner/production/ProductionSourceOffsetCommitterOffsetTracker.java
@@ -35,6 +35,7 @@ import java.util.Map;
  * on it's own. Since OffsetCommitter interface is not applicable to PushSource class, this will properly work only
  * with Source implementing OffsetCommitter interface.
  */
+// TODO
 public class ProductionSourceOffsetCommitterOffsetTracker implements SourceOffsetTracker {
   private static final Logger LOG = LoggerFactory.getLogger(ProductionSourceOffsetCommitterOffsetTracker.class);
   private final OffsetCommitter offsetCommitter;

--- a/container/src/test/java/com/streamsets/datacollector/execution/manager/standalone/TestStandalonePipelineManager.java
+++ b/container/src/test/java/com/streamsets/datacollector/execution/manager/standalone/TestStandalonePipelineManager.java
@@ -42,6 +42,7 @@ import com.streamsets.datacollector.main.RuntimeModule;
 import com.streamsets.datacollector.main.StandaloneRuntimeInfo;
 import com.streamsets.datacollector.main.UserGroupManager;
 import com.streamsets.datacollector.runner.MockStages;
+import com.streamsets.datacollector.runner.production.OffsetStorageFactory;
 import com.streamsets.datacollector.stagelibrary.StageLibraryTask;
 import com.streamsets.datacollector.store.AclStoreTask;
 import com.streamsets.datacollector.store.PipelineStoreException;
@@ -102,6 +103,7 @@ public class TestStandalonePipelineManager {
       StandaloneAndClusterPipelineManager.class,
       PipelineStoreTask.class,
       PipelineStateStore.class,
+      OffsetStorageFactory.class,
       StandaloneRunner.class,
       EventListenerManager.class,
       LockCache.class,
@@ -262,6 +264,11 @@ public class TestStandalonePipelineManager {
     @Provides @Singleton
     public StatsCollector provideStatsCollector() {
       return Mockito.mock(StatsCollector.class);
+    }
+
+    @Provides @Singleton
+    public OffsetStorageFactory provideOffsetStorageFactory() {
+      return OffsetStorageFactory.FILE;
     }
 
   }

--- a/container/src/test/java/com/streamsets/datacollector/execution/runner/cluster/TestClusterRunner.java
+++ b/container/src/test/java/com/streamsets/datacollector/execution/runner/cluster/TestClusterRunner.java
@@ -41,6 +41,7 @@ import com.streamsets.datacollector.main.StandaloneRuntimeInfo;
 import com.streamsets.datacollector.main.UserGroupManager;
 import com.streamsets.datacollector.runner.MockStages;
 import com.streamsets.datacollector.runner.PipelineRuntimeException;
+import com.streamsets.datacollector.runner.production.OffsetStorageFactory;
 import com.streamsets.datacollector.stagelibrary.StageLibraryTask;
 import com.streamsets.datacollector.store.AclStoreTask;
 import com.streamsets.datacollector.store.PipelineStoreException;
@@ -217,7 +218,8 @@ public class TestClusterRunner {
           eventListenerManager,
           sdcToken,
           new FileAclStoreTask(runtimeInfo, pipelineStore, new LockCache<String>(),
-              Mockito.mock(UserGroupManager.class))
+              Mockito.mock(UserGroupManager.class)),
+          OffsetStorageFactory.FILE
       );
     }
 
@@ -700,7 +702,7 @@ public class TestClusterRunner {
     eventListenerManager = new EventListenerManager();
     return new ClusterRunner(NAME, "0", runtimeInfo, conf, pipelineStoreTask, pipelineStateStore,
       stageLibraryTask, executorService, clusterHelper, new ResourceManager(conf), eventListenerManager, "myToken",
-      aclStoreTask);
+      aclStoreTask, OffsetStorageFactory.FILE);
   }
 
   private Runner createRunnerForRetryTest(PipelineStateStore pipelineStateStore) {
@@ -714,7 +716,7 @@ public class TestClusterRunner {
   private Runner createClusterRunner(String name, PipelineStoreTask pipelineStoreTask, ResourceManager resourceManager) {
     eventListenerManager = new EventListenerManager();
     Runner runner = new ClusterRunner(name, "0", runtimeInfo, conf, pipelineStoreTask, pipelineStateStore,
-      stageLibraryTask, executorService, clusterHelper, resourceManager, eventListenerManager, "myToken", aclStoreTask);
+      stageLibraryTask, executorService, clusterHelper, resourceManager, eventListenerManager, "myToken", aclStoreTask, OffsetStorageFactory.FILE);
     eventListenerManager.addStateEventListener(resourceManager);
     return runner;
   }
@@ -735,7 +737,8 @@ public class TestClusterRunner {
         new ResourceManager(conf),
         eventListenerManager,
         "myToken",
-        aclStoreTask
+        aclStoreTask,
+        OffsetStorageFactory.FILE
       ),
       new SafeScheduledExecutorService(1, "runner"),
       new SafeScheduledExecutorService(1, "runnerStop")
@@ -753,7 +756,7 @@ public class TestClusterRunner {
       super(name, rev, runtimeInfo, configuration, pipelineStore, pipelineStateStore, stageLibrary, executorService,
         clusterHelper, resourceManager, eventListenerManager, "myToken",
         new FileAclStoreTask(runtimeInfo, pipelineStore, new LockCache<String>(),
-            Mockito.mock(UserGroupManager.class)));
+            Mockito.mock(UserGroupManager.class)), OffsetStorageFactory.FILE);
     }
 
     @Override

--- a/container/src/test/java/com/streamsets/datacollector/execution/runner/common/TestErrorRecord.java
+++ b/container/src/test/java/com/streamsets/datacollector/execution/runner/common/TestErrorRecord.java
@@ -33,6 +33,7 @@ import com.streamsets.datacollector.runner.MockStages;
 import com.streamsets.datacollector.runner.Pipeline;
 import com.streamsets.datacollector.runner.SourceResponseSink;
 import com.streamsets.datacollector.runner.production.BadRecordsHandler;
+import com.streamsets.datacollector.runner.production.OffsetStorageFactory;
 import com.streamsets.datacollector.usagestats.StatsCollector;
 import com.streamsets.datacollector.util.Configuration;
 import com.streamsets.datacollector.util.TestUtil;
@@ -209,7 +210,8 @@ public class TestErrorRecord {
         null,
         Mockito.mock(BlobStoreTask.class),
         Mockito.mock(LineagePublisherTask.class),
-        Mockito.mock(StatsCollector.class)
+        Mockito.mock(StatsCollector.class),
+        OffsetStorageFactory.FILE
     ).build(
         MockStages.userContext(),
         MockStages.createPipelineConfigurationSourceProcessorTarget(),

--- a/container/src/test/java/com/streamsets/datacollector/execution/runner/common/TestFailedProdRun.java
+++ b/container/src/test/java/com/streamsets/datacollector/execution/runner/common/TestFailedProdRun.java
@@ -18,6 +18,7 @@ package com.streamsets.datacollector.execution.runner.common;
 import com.codahale.metrics.MetricRegistry;
 import com.streamsets.datacollector.blobstore.BlobStoreTask;
 import com.streamsets.datacollector.lineage.LineagePublisherTask;
+import com.streamsets.datacollector.runner.production.OffsetStorageFactory;
 import com.streamsets.datacollector.usagestats.StatsCollector;
 import com.streamsets.datacollector.util.PipelineDirectoryUtil;
 import com.streamsets.pipeline.api.BatchMaker;
@@ -98,7 +99,8 @@ public class TestFailedProdRun {
       null,
       Mockito.mock(BlobStoreTask.class),
       Mockito.mock(LineagePublisherTask.class),
-      Mockito.mock(StatsCollector.class)
+      Mockito.mock(StatsCollector.class),
+      OffsetStorageFactory.FILE
     ).build(
       MockStages.userContext(),
       pipelineConfiguration,
@@ -161,7 +163,8 @@ public class TestFailedProdRun {
       null,
       Mockito.mock(BlobStoreTask.class),
       Mockito.mock(LineagePublisherTask.class),
-      Mockito.mock(StatsCollector.class)
+      Mockito.mock(StatsCollector.class),
+      OffsetStorageFactory.FILE
     ).build(
       MockStages.userContext(),
       pipelineConfiguration,

--- a/container/src/test/java/com/streamsets/datacollector/execution/runner/common/TestProdPipelineRunnable.java
+++ b/container/src/test/java/com/streamsets/datacollector/execution/runner/common/TestProdPipelineRunnable.java
@@ -32,6 +32,7 @@ import com.streamsets.datacollector.main.RuntimeInfo;
 import com.streamsets.datacollector.main.RuntimeModule;
 import com.streamsets.datacollector.runner.MockStages;
 import com.streamsets.datacollector.runner.SourceOffsetTracker;
+import com.streamsets.datacollector.runner.production.OffsetStorageFactory;
 import com.streamsets.datacollector.usagestats.StatsCollector;
 import com.streamsets.datacollector.util.Configuration;
 import com.streamsets.datacollector.util.PipelineException;
@@ -142,7 +143,8 @@ public class TestProdPipelineRunnable {
       null,
       Mockito.mock(BlobStoreTask.class),
       Mockito.mock(LineagePublisherTask.class),
-      Mockito.mock(StatsCollector.class)
+      Mockito.mock(StatsCollector.class),
+      OffsetStorageFactory.FILE
     ).build(
       MockStages.userContext(),
       MockStages.createPipelineConfigurationSourceProcessorTarget(),

--- a/container/src/test/java/com/streamsets/datacollector/execution/runner/common/TestProductionPipeline.java
+++ b/container/src/test/java/com/streamsets/datacollector/execution/runner/common/TestProductionPipeline.java
@@ -38,6 +38,7 @@ import com.streamsets.datacollector.runner.Pipeline;
 import com.streamsets.datacollector.runner.PipelineRuntimeException;
 import com.streamsets.datacollector.runner.SourceOffsetTracker;
 import com.streamsets.datacollector.runner.SourcePipe;
+import com.streamsets.datacollector.runner.production.OffsetStorageFactory;
 import com.streamsets.datacollector.runner.production.StatsAggregationHandler;
 import com.streamsets.datacollector.usagestats.StatsCollector;
 import com.streamsets.datacollector.util.Configuration;
@@ -457,7 +458,8 @@ public class TestProductionPipeline {
       null,
       Mockito.mock(BlobStoreTask.class),
       Mockito.mock(LineagePublisherTask.class),
-      Mockito.mock(StatsCollector.class)
+      Mockito.mock(StatsCollector.class),
+      OffsetStorageFactory.FILE
     ).build(
       MockStages.userContext(),
       pConf,

--- a/container/src/test/java/com/streamsets/datacollector/runner/TestZookeeperOffsetStorage.java
+++ b/container/src/test/java/com/streamsets/datacollector/runner/TestZookeeperOffsetStorage.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2017 StreamSets Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.streamsets.datacollector.runner;
+
+import com.google.common.collect.ImmutableMap;
+import com.streamsets.datacollector.main.RuntimeInfo;
+import com.streamsets.datacollector.runner.production.OffsetStorage;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.retry.RetryUntilElapsed;
+import org.apache.zookeeper.server.NIOServerCnxnFactory;
+import org.apache.zookeeper.server.ZooKeeperServer;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.util.Collections;
+import java.util.Map;
+
+public class TestZookeeperOffsetStorage {
+
+  @Rule
+  public TemporaryFolder snapDir = new TemporaryFolder();
+  public TemporaryFolder logDir = new TemporaryFolder();
+  private NIOServerCnxnFactory factory;
+  private CuratorFramework client;
+  private int port;
+
+  @Before
+  public void startZookeeper() throws Exception {
+    snapDir.create();
+    logDir.create();
+
+    port = getFreePort();
+    ZooKeeperServer server = new ZooKeeperServer(snapDir.newFolder(), logDir.newFolder(), 1000);
+    factory = new NIOServerCnxnFactory();
+    factory.configure(new InetSocketAddress("localhost", port), 16);
+    factory.startup(server);
+    client = CuratorFrameworkFactory.newClient("localhost:" + port, new RetryUntilElapsed(2000, 100));
+    client.start();
+  }
+
+  public void stopZookeeper() throws Exception {
+    client.close();
+    factory.shutdown();
+  }
+
+  @Test
+  public void testSaveAndGetOffsets() throws Exception {
+    RuntimeInfo runtimeInfo = Mockito.mock(RuntimeInfo.class);
+
+    OffsetStorage.ZookeeperStorage storage = new OffsetStorage.ZookeeperStorage(client, "sdc");
+    Map<String, String> offsets = ImmutableMap.of("a", "b", "c", "d");
+    storage.saveOffsets(runtimeInfo, "a", "0", offsets);
+    Assert.assertEquals(
+        storage.getAndSaveIfEmpty(runtimeInfo, "a", "0"),
+        offsets
+    );
+  }
+
+  @Test
+  public void testGetEmptyOffsets() throws Exception {
+    RuntimeInfo runtimeInfo = Mockito.mock(RuntimeInfo.class);
+
+    OffsetStorage.ZookeeperStorage storage = new OffsetStorage.ZookeeperStorage(client, "sdc");
+    Assert.assertEquals(
+      storage.getAndSaveIfEmpty(runtimeInfo, "a", "1"),
+      Collections.emptyMap()
+    );
+  }
+
+  @Test
+  public void testResetOffsets() throws Exception {
+    RuntimeInfo runtimeInfo = Mockito.mock(RuntimeInfo.class);
+
+    OffsetStorage.ZookeeperStorage storage = new OffsetStorage.ZookeeperStorage(client, "sdc");
+    Map<String, String> offsets = ImmutableMap.of("a", "b", "c", "d");
+    storage.saveOffsets(runtimeInfo, "a", "0", offsets);
+    Assert.assertEquals(
+        storage.getAndSaveIfEmpty(runtimeInfo, "a", "0"),
+        offsets
+    );
+    storage.resetOffsets(runtimeInfo, "a", "0");
+
+    Assert.assertEquals(
+        storage.getAndSaveIfEmpty(runtimeInfo, "a", "0"),
+        Collections.emptyMap()
+    );
+  }
+
+  public static int getFreePort() throws IOException {
+    ServerSocket serverSocket = new ServerSocket(0);
+    int port = serverSocket.getLocalPort();
+    serverSocket.close();
+    return port;
+  }
+}

--- a/container/src/test/java/com/streamsets/datacollector/runner/production/TestProductionSourceOffsetTracker.java
+++ b/container/src/test/java/com/streamsets/datacollector/runner/production/TestProductionSourceOffsetTracker.java
@@ -71,7 +71,12 @@ public class TestProductionSourceOffsetTracker {
     );
     Files.createDirectories(PipelineDirectoryUtil.getPipelineDir(info, PIPELINE_NAME, PIPELINE_REV).toPath());
     OffsetFileUtil.resetOffsets(info, PIPELINE_NAME, PIPELINE_REV);
-    offsetTracker = new ProductionSourceOffsetTracker(PIPELINE_NAME, PIPELINE_REV, info);
+    offsetTracker = new ProductionSourceOffsetTracker(
+        PIPELINE_NAME,
+        PIPELINE_REV,
+        info,
+        new OffsetStorage.FileStorage()
+    );
   }
 
   @Test

--- a/dist/src/main/etc/sdc.properties
+++ b/dist/src/main/etc/sdc.properties
@@ -427,3 +427,17 @@ store.pipeline.state.cache.maximum.size=100
 # has elapsed after the entry's creation, the most recent replacement of its value, or its last access.
 # In minutes
 store.pipeline.state.cache.expire.after.access=10
+
+# Specifies where pipeline offsets are stored. Either in plain files, or zookeeper.
+# Possible values = file | zookeeper
+offsets.storage.type=file
+
+# Uncomment if using zookeeper offsets storage
+# all zookeeper nodes addresses, comma separated
+#offsets.storage.zookeeper.address=localhost:2181
+# prefix for sdc offsets path
+#offsets.storage.zookeeper.prefix=streamsets
+# connection timeout millis
+offsets.storage.zookeeper.connect_timeout=5000
+# time millis to wait between connection attempts
+offsets.storage.zookeeper.reconnect_pause=500


### PR DESCRIPTION
… in external storage, not only in file. As for now supports only storing offsets in files and in zookeeper. Offset storage is configured for whole sdc instance, not per-pipeline.