### PR TITLE
This commit fixes the build errors, if built with HEAD of datacollector-api

### DIFF
--- a/container/src/test/java/com/streamsets/datacollector/creation/TestPipelineBeanCreator.java
+++ b/container/src/test/java/com/streamsets/datacollector/creation/TestPipelineBeanCreator.java
@@ -34,6 +34,7 @@ import com.streamsets.datacollector.stagelibrary.StageLibraryTask;
 import com.streamsets.datacollector.validation.Issue;
 import com.streamsets.pipeline.api.Batch;
 import com.streamsets.pipeline.api.BatchMaker;
+import com.streamsets.pipeline.api.BlobStoreDef;
 import com.streamsets.pipeline.api.Config;
 import com.streamsets.pipeline.api.ConfigDef;
 import com.streamsets.pipeline.api.ConfigDefBean;
@@ -367,6 +368,11 @@ public class TestPipelineBeanCreator {
     @Override
     public Interceptor create(Context context) {
       return new MyInterceptor(context.getStageType().name() + " " + context.getInterceptorType().name());
+    }
+
+    @Override
+    public List<BlobStoreDef> blobStoreResource(Map<String, String> parameters){
+        return null;
     }
   }
 

--- a/container/src/test/java/com/streamsets/datacollector/definition/InterceptorDefinitionExtractorTest.java
+++ b/container/src/test/java/com/streamsets/datacollector/definition/InterceptorDefinitionExtractorTest.java
@@ -19,12 +19,14 @@ import com.streamsets.datacollector.config.InterceptorDefinition;
 import com.streamsets.datacollector.config.StageLibraryDefinition;
 import com.streamsets.pipeline.api.Record;
 import com.streamsets.pipeline.api.interceptor.BaseInterceptor;
+import com.streamsets.pipeline.api.BlobStoreDef;
 import com.streamsets.pipeline.api.interceptor.Interceptor;
 import com.streamsets.pipeline.api.interceptor.InterceptorCreator;
 import com.streamsets.pipeline.api.interceptor.InterceptorDef;
 import org.junit.Test;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 
 import static org.junit.Assert.assertEquals;
@@ -36,6 +38,11 @@ public class InterceptorDefinitionExtractorTest {
     @Override
     public Interceptor create(Context context) {
       return null;
+    }
+
+    @Override
+    public List<BlobStoreDef> blobStoreResource(Map<String, String> parameters){
+        return null;
     }
   }
 


### PR DESCRIPTION
The problem was in some test files that did not override all the
abstract methods of interceptor. Introduced in commit e1acbafe4be999c90ef8bf98021174af5b994ee3
in datacollector-api