### PR TITLE
[SDC-10803] Add UnknownTypeAction to streamsets-datacollector-jdbc-protolib CDC

### DIFF
--- a/jdbc-protolib/src/main/java/com/streamsets/pipeline/stage/origin/jdbc/CT/sqlserver/CTTableJdbcConfigBean.java
+++ b/jdbc-protolib/src/main/java/com/streamsets/pipeline/stage/origin/jdbc/CT/sqlserver/CTTableJdbcConfigBean.java
@@ -25,6 +25,8 @@ import com.streamsets.pipeline.lib.jdbc.JdbcErrors;
 import com.streamsets.pipeline.lib.jdbc.multithread.BatchTableStrategy;
 import com.streamsets.pipeline.lib.jdbc.multithread.BatchTableStrategyChooserValues;
 import com.streamsets.pipeline.lib.jdbc.multithread.TableOrderStrategy;
+import com.streamsets.pipeline.lib.jdbc.UnknownTypeAction;
+import com.streamsets.pipeline.lib.jdbc.UnknownTypeActionChooserValues;
 import com.streamsets.pipeline.stage.origin.jdbc.CT.TableOrderStrategyChooserValues;
 
 import java.util.List;
@@ -139,6 +141,18 @@ public class CTTableJdbcConfigBean {
       group = "JDBC"
   )
   public int fetchSize;
+
+  @ConfigDef(
+          required = true,
+          type = ConfigDef.Type.MODEL,
+          label = "On Unknown Type",
+          description = "Action that should be performed when an unknown type is detected in the result set.",
+          defaultValue = "STOP_PIPELINE",
+          displayPosition = 230,
+          group = "ADVANCED"
+  )
+  @ValueChooserModel(UnknownTypeActionChooserValues.class)
+  public UnknownTypeAction unknownTypeAction = UnknownTypeAction.STOP_PIPELINE;
 
   public static final String TABLE_JDBC_CONFIG_BEAN_PREFIX = "tableJdbcConfigBean.";
   public static final String TABLE_CONFIG = TABLE_JDBC_CONFIG_BEAN_PREFIX + "tableConfigs";

--- a/jdbc-protolib/src/main/java/com/streamsets/pipeline/stage/origin/jdbc/CT/sqlserver/SQLServerCTDSource.java
+++ b/jdbc-protolib/src/main/java/com/streamsets/pipeline/stage/origin/jdbc/CT/sqlserver/SQLServerCTDSource.java
@@ -67,6 +67,7 @@ public class SQLServerCTDSource extends DPushSource {
     tableJdbcConfigBean.quoteChar = QuoteChar.NONE;
     tableJdbcConfigBean.numberOfThreads = ctTableJdbcConfigBean.numberOfThreads;
     tableJdbcConfigBean.tableOrderStrategy = ctTableJdbcConfigBean.tableOrderStrategy;
+    tableJdbcConfigBean.unknownTypeAction = ctTableJdbcConfigBean.unknownTypeAction;
 
     return tableJdbcConfigBean;
   }

--- a/jdbc-protolib/src/main/java/com/streamsets/pipeline/stage/origin/jdbc/cdc/sqlserver/CDCTableJdbcConfigBean.java
+++ b/jdbc-protolib/src/main/java/com/streamsets/pipeline/stage/origin/jdbc/cdc/sqlserver/CDCTableJdbcConfigBean.java
@@ -25,6 +25,8 @@ import com.streamsets.pipeline.lib.jdbc.JdbcErrors;
 import com.streamsets.pipeline.lib.jdbc.multithread.BatchTableStrategy;
 import com.streamsets.pipeline.lib.jdbc.multithread.BatchTableStrategyChooserValues;
 import com.streamsets.pipeline.lib.jdbc.multithread.TableOrderStrategy;
+import com.streamsets.pipeline.lib.jdbc.UnknownTypeAction;
+import com.streamsets.pipeline.lib.jdbc.UnknownTypeActionChooserValues;
 import com.streamsets.pipeline.stage.origin.jdbc.cdc.TableOrderStrategyChooserValues;
 
 import java.util.List;
@@ -138,6 +140,18 @@ public class CDCTableJdbcConfigBean {
       group = "ADVANCED"
   )
   public boolean isReconnect;
+
+  @ConfigDef(
+      required = true,
+      type = ConfigDef.Type.MODEL,
+      label = "On Unknown Type",
+      description = "Action that should be performed when an unknown type is detected in the result set.",
+      defaultValue = "STOP_PIPELINE",
+      displayPosition = 230,
+      group = "ADVANCED"
+  )
+  @ValueChooserModel(UnknownTypeActionChooserValues.class)
+  public UnknownTypeAction unknownTypeAction = UnknownTypeAction.STOP_PIPELINE;
 
   public static final String TABLE_JDBC_CONFIG_BEAN_PREFIX = "tableJdbcConfigBean.";
   public static final String TABLE_CONFIG = TABLE_JDBC_CONFIG_BEAN_PREFIX + "tableConfigs";

--- a/jdbc-protolib/src/main/java/com/streamsets/pipeline/stage/origin/jdbc/cdc/sqlserver/SQLServerCDCDSource.java
+++ b/jdbc-protolib/src/main/java/com/streamsets/pipeline/stage/origin/jdbc/cdc/sqlserver/SQLServerCDCDSource.java
@@ -61,6 +61,7 @@ public class SQLServerCDCDSource extends DPushSource {
     tableJdbcConfigBean.timeZoneID = "UTC";
     tableJdbcConfigBean.numberOfThreads = cdcTableJdbcConfigBean.numberOfThreads;
     tableJdbcConfigBean.tableOrderStrategy = cdcTableJdbcConfigBean.tableOrderStrategy;
+    tableJdbcConfigBean.unknownTypeAction = cdcTableJdbcConfigBean.unknownTypeAction;
 
     return tableJdbcConfigBean;
   }


### PR DESCRIPTION
This resolves SDC-10803 and enables the SQL Server CDC and Change Tracking stages to cast unknown types to a string or stop the pipeline as the Multitable JDBC stage allows.

Your CLA page is broken, AdobeSign iframe is redirecting back to your homepage (removed broken image)
