### PR TITLE
Fixed postgres metadata processor to handle dynamic records within the same batch

### DIFF
--- a/jdbc-protolib/src/main/java/com/streamsets/pipeline/lib/jdbc/JdbcMetastoreUtil.java
+++ b/jdbc-protolib/src/main/java/com/streamsets/pipeline/lib/jdbc/JdbcMetastoreUtil.java
@@ -107,4 +107,16 @@ public class JdbcMetastoreUtil {
     }
     return columnDiff;
   }
+
+  public static LinkedHashMap<String, JdbcTypeInfo> getUpdatedStructure(
+      LinkedHashMap<String, JdbcTypeInfo> oldState,
+      LinkedHashMap<String, JdbcTypeInfo> columnDiff
+  ) {
+    for (Map.Entry<String, JdbcTypeInfo> entry : columnDiff.entrySet()) {
+      String columnName = entry.getKey();
+      JdbcTypeInfo columnTypeInfo = entry.getValue();
+      oldState.put(columnName, columnTypeInfo);
+    }
+    return oldState;
+  }
 }

--- a/jdbc-protolib/src/main/java/com/streamsets/pipeline/stage/processor/jdbcmetadata/JdbcMetadataProcessor.java
+++ b/jdbc-protolib/src/main/java/com/streamsets/pipeline/stage/processor/jdbcmetadata/JdbcMetadataProcessor.java
@@ -201,7 +201,7 @@ public class JdbcMetadataProcessor extends RecordProcessor {
               StringUtils.join(columnDiff.keySet(), ",")
           );
           schemaWriter.alterTable(schema, tableName, columnDiff);
-          tableCache.put(Pair.of(schema, tableName), recordStructure);
+          tableCache.put(Pair.of(schema, tableName), JdbcMetastoreUtil.getUpdatedStructure(tableStructure, columnDiff));
         }
       }
 


### PR DESCRIPTION
The existing code works on this kind of data
```
#### record: 1 
{
  "a": 1,
  "b": 2
}

#### record: 2 
{
  "a": 1,
  "b": 2,
  "c": 3
}
```

But fails on the following kind of data as the `tableCache ` gets updated to the structure of `record: 3` and then it will try again to insert the key `c` for `record: 4` thus giving an error `key already exist`
```
#### record: 1 
{
  "a": 1,
  "b": 2
}

#### record: 2 
{
  "a": 1,
  "b": 2,
  "c": 3
}

#### record: 3 
{
  "a": 1,
  "b": 2
}

#### record: 4 
{
  "a": 1,
  "b": 2,
  "c": 3
}
```

