### PR TITLE
Allow to use Azure event hubs with credentials stores

### DIFF
--- a/azure-lib/src/main/java/com/streamsets/pipeline/lib/eventhubs/EventHubCommon.java
+++ b/azure-lib/src/main/java/com/streamsets/pipeline/lib/eventhubs/EventHubCommon.java
@@ -19,13 +19,21 @@ import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.microsoft.azure.eventhubs.ConnectionStringBuilder;
 import com.microsoft.azure.eventhubs.EventHubClient;
 import com.microsoft.azure.eventhubs.EventHubException;
+import com.streamsets.pipeline.api.Stage;
+import com.streamsets.pipeline.api.StageException;
+import com.streamsets.pipeline.api.Target;
+import com.streamsets.pipeline.api.credential.CredentialValue;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 
 public class EventHubCommon {
 
+  private static final Logger LOG = LoggerFactory.getLogger(EventHubCommon.class);
   public final static String CONF_NAME_SPACE = "commonConf.namespaceName";
   private final EventHubConfigBean commonConf;
 
@@ -33,12 +41,12 @@ public class EventHubCommon {
     this.commonConf = commonConf;
   }
 
-  public EventHubClient createEventHubClient(String threadNamePattern) throws IOException, EventHubException {
+  public EventHubClient createEventHubClient(String threadNamePattern) throws IOException, EventHubException, StageException {
     final ConnectionStringBuilder connStr = new ConnectionStringBuilder()
-        .setNamespaceName(commonConf.namespaceName)
-        .setEventHubName(commonConf.eventHubName)
-        .setSasKey(commonConf.sasKey)
-        .setSasKeyName(commonConf.sasKeyName);
+        .setNamespaceName(commonConf.namespaceName.get())
+        .setEventHubName(commonConf.eventHubName.get())
+        .setSasKey(commonConf.sasKey.get())
+        .setSasKeyName(commonConf.sasKeyName.get());
 
     final Executor executor = Executors.newCachedThreadPool(
         new ThreadFactoryBuilder().setNameFormat(threadNamePattern).build()

--- a/azure-lib/src/main/java/com/streamsets/pipeline/lib/eventhubs/EventHubConfigBean.java
+++ b/azure-lib/src/main/java/com/streamsets/pipeline/lib/eventhubs/EventHubConfigBean.java
@@ -16,50 +16,51 @@
 package com.streamsets.pipeline.lib.eventhubs;
 
 import com.streamsets.pipeline.api.ConfigDef;
+import com.streamsets.pipeline.api.credential.CredentialValue;
 
 public class EventHubConfigBean {
 
   @ConfigDef(
       required = true,
-      type = ConfigDef.Type.STRING,
+      type = ConfigDef.Type.CREDENTIAL,
       label = "Namespace Name",
       defaultValue = "",
       description = "Namespace that contains the event hub",
       displayPosition = 10,
       group = "EVENT_HUB"
   )
-  public String namespaceName = "";
+  public CredentialValue namespaceName = "";
 
   @ConfigDef(
       required = true,
-      type = ConfigDef.Type.STRING,
+      type = ConfigDef.Type.CREDENTIAL,
       label = "Event Hub Name",
       defaultValue = "",
       description = "",
       displayPosition = 20,
       group = "EVENT_HUB"
   )
-  public String eventHubName = "";
+  public CredentialValue eventHubName = "";
 
   @ConfigDef(
       required = true,
-      type = ConfigDef.Type.STRING,
+      type = ConfigDef.Type.CREDENTIAL,
       label = "Shared Access Policy Name",
       defaultValue = "",
       description = "Name of a shared access policy associated with the namespace",
       displayPosition = 30,
       group = "EVENT_HUB"
   )
-  public String sasKeyName = "";
+  public CredentialValue sasKeyName = "";
 
   @ConfigDef(
       required = true,
-      type = ConfigDef.Type.STRING,
+      type = ConfigDef.Type.CREDENTIAL,
       label = "Connection String Key",
       defaultValue = "",
       description = "One of the connection string key values associated with the policy",
       displayPosition = 40,
       group = "EVENT_HUB"
   )
-  public String sasKey = "";
+  public CredentialValue sasKey = "";
 }

--- a/azure-lib/src/main/java/com/streamsets/pipeline/stage/origin/eventhubs/EventHubConsumerSource.java
+++ b/azure-lib/src/main/java/com/streamsets/pipeline/stage/origin/eventhubs/EventHubConsumerSource.java
@@ -111,10 +111,10 @@ public class EventHubConsumerSource implements PushSource, IEventProcessorFactor
     List<EventProcessorHost> eventProcessorHostList = new ArrayList<>();
     try {
       ConnectionStringBuilder eventHubConnectionString = new ConnectionStringBuilder()
-          .setNamespaceName(commonConf.namespaceName)
-          .setEventHubName(commonConf.eventHubName)
-          .setSasKey(commonConf.sasKey)
-          .setSasKeyName(commonConf.sasKeyName);
+          .setNamespaceName(commonConf.namespaceName.get())
+          .setEventHubName(commonConf.eventHubName.get())
+          .setSasKey(commonConf.sasKey.get())
+          .setSasKeyName(commonConf.sasKeyName.get());
 
       String storageConnectionString = "DefaultEndpointsProtocol=https;AccountName=" +
           consumerConfigBean.storageAccountName + ";AccountKey=" + consumerConfigBean.storageAccountKey;
@@ -122,7 +122,7 @@ public class EventHubConsumerSource implements PushSource, IEventProcessorFactor
       for (int i = 0; i < consumerConfigBean.maxThreads; i++) {
         EventProcessorHost eventProcessorHost = new EventProcessorHost(
             consumerConfigBean.hostNamePrefix + i,
-            commonConf.eventHubName,
+            commonConf.eventHubName.get(),
             consumerConfigBean.consumerGroup,
             eventHubConnectionString.toString(),
             storageConnectionString,

--- a/azure-lib/src/test/java/com/streamsets/pipeline/stage/destination/eventhubs/EventHubProducerTargetBuilder.java
+++ b/azure-lib/src/test/java/com/streamsets/pipeline/stage/destination/eventhubs/EventHubProducerTargetBuilder.java
@@ -32,22 +32,22 @@ class EventHubProducerTargetBuilder {
   }
 
   EventHubProducerTargetBuilder namespaceName(String namespaceName) {
-    commonConf.namespaceName = namespaceName;
+    commonConf.namespaceName = () -> namespaceName;
     return this;
   }
 
   EventHubProducerTargetBuilder eventHubName(String eventHubName) {
-    commonConf.eventHubName = eventHubName;
+    commonConf.eventHubName = () -> eventHubName;
     return this;
   }
 
   EventHubProducerTargetBuilder sasKeyName(String sasKeyName) {
-    commonConf.sasKeyName = sasKeyName;
+    commonConf.sasKeyName = () -> sasKeyName;
     return this;
   }
 
   EventHubProducerTargetBuilder sasKey(String sasKey) {
-    commonConf.sasKey = sasKey;
+    commonConf.sasKey = () -> sasKey;
     return this;
   }
 

--- a/azure-lib/src/test/java/com/streamsets/pipeline/stage/origin/eventhubs/EventHubConsumerSourceBuilder.java
+++ b/azure-lib/src/test/java/com/streamsets/pipeline/stage/origin/eventhubs/EventHubConsumerSourceBuilder.java
@@ -32,22 +32,22 @@ class EventHubConsumerSourceBuilder {
   }
 
   EventHubConsumerSourceBuilder namespaceName(String namespaceName) {
-    commonConf.namespaceName = namespaceName;
+    commonConf.namespaceName = () -> namespaceName;
     return this;
   }
 
   EventHubConsumerSourceBuilder eventHubName(String eventHubName) {
-    commonConf.eventHubName = eventHubName;
+    commonConf.eventHubName = () -> eventHubName;
     return this;
   }
 
   EventHubConsumerSourceBuilder sasKeyName(String sasKeyName) {
-    commonConf.sasKeyName = sasKeyName;
+    commonConf.sasKeyName = () -> sasKeyName;
     return this;
   }
 
   EventHubConsumerSourceBuilder sasKey(String sasKey) {
-    commonConf.sasKey = sasKey;
+    commonConf.sasKey = () -> sasKey;
     return this;
   }
 


### PR DESCRIPTION
The proposed improvemnt makes it possible to reference credentials from supported credentials stores together with Azure Event Hubs. 
This is to support scenario when it is required to obscure data ppeline destination from pipeline developers to make pipelines portable without hard-coded credentials.