### PR TITLE
SDC-10501 : Option to enable/disable Kafka auto commit Offsets

### DIFF
--- a/kafka-common/src/main/java/com/streamsets/pipeline/lib/kafka/KafkaConstants.java
+++ b/kafka-common/src/main/java/com/streamsets/pipeline/lib/kafka/KafkaConstants.java
@@ -25,5 +25,6 @@ public class KafkaConstants {
   // Constants specific for new consumer/producer library
   public static final String AUTO_OFFSET_RESET_CONFIG = "auto.offset.reset";
   public static final String AUTO_OFFSET_RESET_PREVIEW_VALUE = "earliest";
+  public static final String AUTO_COMMIT_OFFEST = "enable.auto.commit";
 
 }

--- a/kafka_multisource-0_10-protolib/src/main/java/com/streamsets/pipeline/stage/origin/multikafka/v0_10/loader/Kafka0_10ConsumerLoader.java
+++ b/kafka_multisource-0_10-protolib/src/main/java/com/streamsets/pipeline/stage/origin/multikafka/v0_10/loader/Kafka0_10ConsumerLoader.java
@@ -173,5 +173,8 @@ public class Kafka0_10ConsumerLoader extends KafkaConsumerLoader {
     public void close() {
       delegate.close();
     }
+
+    @Override
+    public void commitSync() { delegate.commitSync(); }
   }
 }

--- a/kafka_multisource-0_9-protolib/src/main/java/com/streamsets/pipeline/stage/origin/multikafka/v0_9/loader/Kafka0_9ConsumerLoader.java
+++ b/kafka_multisource-0_9-protolib/src/main/java/com/streamsets/pipeline/stage/origin/multikafka/v0_9/loader/Kafka0_9ConsumerLoader.java
@@ -82,5 +82,8 @@ public class Kafka0_9ConsumerLoader extends KafkaConsumerLoader {
     public void close() {
       delegate.close();
     }
+
+    @Override
+    public void commitSync() { delegate.commitSync(); }
   }
 }

--- a/kafka_multisource-protolib/src/main/java/com/streamsets/pipeline/stage/origin/multikafka/MultiSdcKafkaConsumer.java
+++ b/kafka_multisource-protolib/src/main/java/com/streamsets/pipeline/stage/origin/multikafka/MultiSdcKafkaConsumer.java
@@ -33,4 +33,6 @@ public interface MultiSdcKafkaConsumer<K, V> {
   public void unsubscribe();
 
   public void close();
+
+  public void commitSync();
 }

--- a/kafka_multisource-protolib/src/test/java/com/streamsets/pipeline/stage/origin/multikafka/loader/MockKafkaConsumerLoader.java
+++ b/kafka_multisource-protolib/src/test/java/com/streamsets/pipeline/stage/origin/multikafka/loader/MockKafkaConsumerLoader.java
@@ -87,5 +87,8 @@ public class MockKafkaConsumerLoader extends KafkaConsumerLoader {
     public void close() {
       delegate.close();
     }
+
+    @Override
+    public void commitSync() { delegate.commitSync(); }
   }
 }


### PR DESCRIPTION
JIRA: SDC-10501 Kafka Multi-Topic Consumer not checking delivery guarantee

Toggle Option for Kafka enable.auto.commit.

- The consumer can either automatically commit offsets periodically, default enable.auto.commit=true, with auto.commit.interval.ms=1000 interval. 
- Or it can choose to control this committed position manually by calling one of the commit commitSync after finishing processing messages.  