### PR TITLE
SDC-11243 Add "JDBC Driver Class Name" config to MySQL Binary Log origin

### DIFF
--- a/mysql-binlog-lib/src/main/java/com/streamsets/pipeline/stage/origin/mysql/Errors.java
+++ b/mysql-binlog-lib/src/main/java/com/streamsets/pipeline/stage/origin/mysql/Errors.java
@@ -26,7 +26,8 @@ public enum Errors implements ErrorCode {
   MYSQL_004("Error processing MySql event {} at offset {}: {}"),
   MYSQL_006("MySql server error: {}"),
   MYSQL_007("Ignore tables format error: {}"),
-  MYSQL_008("Include tables format error: {}"),;
+  MYSQL_008("Include tables format error: {}"),
+  MYSQL_009("Driver class not found: {}"),;
   private final String msg;
 
   Errors(String msg) {

--- a/mysql-binlog-lib/src/main/java/com/streamsets/pipeline/stage/origin/mysql/MysqlSource.java
+++ b/mysql-binlog-lib/src/main/java/com/streamsets/pipeline/stage/origin/mysql/MysqlSource.java
@@ -142,6 +142,16 @@ public abstract class MysqlSource extends BaseSource {
     hikariConfig.setPassword(getConfig().password);
     hikariConfig.setReadOnly(true);
     hikariConfig.addDataSourceProperty("useSSL", getConfig().useSsl);
+    if (getConfig().driverClassName != null && !getConfig().driverClassName.isEmpty()) {
+      try {
+        Class.forName(getConfig().driverClassName);
+      } catch (ClassNotFoundException e) {
+        LOG.error("Driver class not found: {}", e.getMessage(), e);
+        issues.add(getContext().createConfigIssue(
+            Groups.ADVANCED.name(), null, Errors.MYSQL_009, e.getMessage(), e
+        ));
+      }
+    }
     try {
       dataSource = new HikariDataSource(hikariConfig);
       offsetFactory = isGtidEnabled()

--- a/mysql-binlog-lib/src/main/java/com/streamsets/pipeline/stage/origin/mysql/MysqlSourceConfig.java
+++ b/mysql-binlog-lib/src/main/java/com/streamsets/pipeline/stage/origin/mysql/MysqlSourceConfig.java
@@ -147,6 +147,16 @@ public class MysqlSourceConfig {
   public boolean useSsl;
 
   @ConfigDef(
+      required = false,
+      type = ConfigDef.Type.STRING,
+      label = "JDBC Driver Class Name",
+      description = "Class name for pre-JDBC 4 compliant drivers.",
+      displayPosition = 85,
+      group = "ADVANCED"
+  )
+  public String driverClassName;
+
+  @ConfigDef(
       required = true,
       type = ConfigDef.Type.BOOLEAN,
       defaultValue = "false",


### PR DESCRIPTION
Useful for working around driver loading issues when using multiple JDBC origins (eg. when a pipeline using Oracle CDC Client origin starts before a pipeline using this origin.)