### PR TITLE
Using JSON Entities breaks scroll functionality in Elasticsearch 1.x

### DIFF
--- a/elasticsearch-protolib/src/main/java/com/streamsets/pipeline/lib/elasticsearch/ElasticsearchStageDelegate.java
+++ b/elasticsearch-protolib/src/main/java/com/streamsets/pipeline/lib/elasticsearch/ElasticsearchStageDelegate.java
@@ -197,6 +197,15 @@ public class ElasticsearchStageDelegate {
     return restClient.performRequest(method, endpoint, params, entity, headers);
   }
 
+  public Response performRequest(
+          String method,
+          String endpoint,
+          Map<String, String> params,
+          Header... headers
+  ) throws IOException {
+    return restClient.performRequest(method, endpoint, params, headers);
+  }
+
   private void addSniffer(HttpHost[] hosts) {
     if (conf.clientSniff) {
       switch (hosts[0].getSchemeName()) {

--- a/elasticsearch-protolib/src/main/java/com/streamsets/pipeline/stage/origin/elasticsearch/ElasticsearchSource.java
+++ b/elasticsearch-protolib/src/main/java/com/streamsets/pipeline/stage/origin/elasticsearch/ElasticsearchSource.java
@@ -360,16 +360,15 @@ public class ElasticsearchSource extends BasePushSource {
     }
 
     private JsonObject getResults(String scrollId) throws StageException {
-      HttpEntity entity = new StringEntity(
-          String.format("{\"scroll\":\"%s\",\"scroll_id\":\"%s\"}", conf.cursorTimeout, scrollId),
-          ContentType.APPLICATION_JSON
-      );
+
+      final Map<String, String> requestParams = new HashMap<>(conf.params);
+      requestParams.put("scroll", conf.cursorTimeout);
+      requestParams.put("scroll_id", scrollId);
 
       try {
         Response response = delegate.performRequest("POST",
             "/_search/scroll",
-            conf.params,
-            entity,
+            requestParams,
             delegate.getAuthenticationHeader(conf.securityConfig.securityUser.get())
         );
 
@@ -386,15 +385,14 @@ public class ElasticsearchSource extends BasePushSource {
         return;
       }
 
-      HttpEntity entity = new StringEntity(
-          String.format("{\"scroll_id\":[\"%s\"]}", scrollId),
-          ContentType.APPLICATION_JSON
-      );
+      final Map<String, String> requestParams = new HashMap<>(conf.params);
+      requestParams.put("scroll_id", scrollId);
+
+      HttpEntity entity = new StringEntity(scrollId,ContentType.APPLICATION_JSON);
       delegate.performRequest(
         "DELETE",
         "/_search/scroll",
-        conf.params,
-        entity,
+        requestParams,
         delegate.getAuthenticationHeader(conf.securityConfig.securityUser.get())
       );
     }


### PR DESCRIPTION
Using query params instead, and is supported past 1.x

You can find an example of how 1.x supports scroll params here:
https://www.elastic.co/guide/en/elasticsearch/reference/1.7/search-request-scroll.html

scroll_id is supported as either a raw text entity (no JSON formatting) or a query param.

Note the following quote:
"The returned _scroll_id attribute can be passed in the request body or in the query string as ?scroll_id=...."

Here is the 5.2 doc: 
https://www.elastic.co/guide/en/elasticsearch/reference/5.2/search-request-scroll.html

Which states that query params still work in future versions past 1.x in lieu of a JSON entity:
"The scroll_id can also be passed as a query string parameter or in the request body."