### PR TITLE
Update DataParserFormatConfig.java

### DIFF
--- a/commonlib/src/main/java/com/streamsets/pipeline/stage/origin/lib/DataParserFormatConfig.java
+++ b/commonlib/src/main/java/com/streamsets/pipeline/stage/origin/lib/DataParserFormatConfig.java
@@ -367,7 +367,7 @@ public class DataParserFormatConfig implements DataFormatConfig {
       defaultValue = "\\",
       label = "Escape Character",
       description = "Character used to escape quote and delimiter characters. To disable select Other and enter " +
-          "\\u0000 (unicode codepoint for the NULL character) in the box.",
+          "\\u0000 (unicode codepoint for the NULL character).",
       displayPosition = 410,
       group = "DATA_FORMAT",
       dependsOn = "csvFileFormat",
@@ -381,7 +381,7 @@ public class DataParserFormatConfig implements DataFormatConfig {
       defaultValue = "\"",
       label = "Quote Character",
       description = "Character used to quote string fields. To disable select Other and enter" +
-          " \\u0000 (unicode codepoint for the NULL character) in the box.",
+          " \\u0000 (unicode codepoint for the NULL character).",
       displayPosition = 420,
       group = "DATA_FORMAT",
       dependsOn = "csvFileFormat",

--- a/commonlib/src/main/java/com/streamsets/pipeline/stage/origin/lib/DataParserFormatConfig.java
+++ b/commonlib/src/main/java/com/streamsets/pipeline/stage/origin/lib/DataParserFormatConfig.java
@@ -366,6 +366,8 @@ public class DataParserFormatConfig implements DataFormatConfig {
       type = ConfigDef.Type.CHARACTER,
       defaultValue = "\\",
       label = "Escape Character",
+      description = "Character used to escape quote and delimiter characters. To disable select Other and enter " +
+          "\\u0000 (unicode codepoint for the NULL character) in the box.",
       displayPosition = 410,
       group = "DATA_FORMAT",
       dependsOn = "csvFileFormat",
@@ -378,6 +380,8 @@ public class DataParserFormatConfig implements DataFormatConfig {
       type = ConfigDef.Type.CHARACTER,
       defaultValue = "\"",
       label = "Quote Character",
+      description = "Character used to quote string fields. To disable select Other and enter" +
+          " \\u0000 (unicode codepoint for the NULL character) in the box.",
       displayPosition = 420,
       group = "DATA_FORMAT",
       dependsOn = "csvFileFormat",


### PR DESCRIPTION
Added comments to tell users how to disable quoting and escaping in delimited files.  When using IANA specification Tab separated values https://www.iana.org/assignments/media-types/text/tab-separated-values quotes and escapes are not defined.  Using the unicode null character \u0000 disables disables these features in Commons CSV.