### PR TITLE
SDC-12695 Extract timestamp and timestamp type in Kafka Multitopic Consumer

### DIFF
--- a/kafka_multisource-protolib/src/main/java/com/streamsets/pipeline/stage/origin/multikafka/MultiKafkaBeanConfig.java
+++ b/kafka_multisource-protolib/src/main/java/com/streamsets/pipeline/stage/origin/multikafka/MultiKafkaBeanConfig.java
@@ -228,6 +228,18 @@ public class MultiKafkaBeanConfig {
   @ValueChooserModel(ValueDeserializerChooserValues.class)
   public Deserializer valueDeserializer = Deserializer.DEFAULT;
 
+  @ConfigDef(
+      required = true,
+      type = ConfigDef.Type.BOOLEAN,
+      defaultValue = "false",
+      label = "Include Timestamps",
+      description = "Includes the timestamps inherited from Kafka in the record header",
+      displayPosition = 130,
+      group = "KAFKA"
+   )
+   public boolean timestampsEnabled;
+
+
   public void init(Stage.Context context, List<Stage.ConfigIssue> issues) {
 
   }

--- a/kafka_multisource-protolib/src/main/java/com/streamsets/pipeline/stage/origin/multikafka/MultiKafkaSource.java
+++ b/kafka_multisource-protolib/src/main/java/com/streamsets/pipeline/stage/origin/multikafka/MultiKafkaSource.java
@@ -140,7 +140,9 @@ public class MultiKafkaSource extends BasePushSource {
                 item.partition(),
                 item.offset(),
                 item.value(),
-                item.key()
+                item.key(),
+                item.timestamp(),
+                item.timestampType().name()
             ));
 
             if (records.size() >= conf.maxBatchSize) {
@@ -206,7 +208,9 @@ public class MultiKafkaSource extends BasePushSource {
         int partition,
         long offset,
         byte[] payload,
-        Object messageKey
+        Object messageKey,
+        long timestamp,
+        String timestampType
     ) throws StageException {
       Utils.checkNotNull(parserFactory, "Initialization failed");
 
@@ -220,6 +224,14 @@ public class MultiKafkaSource extends BasePushSource {
           record.getHeader().setAttribute(HeaderAttributeConstants.TOPIC, topic);
           record.getHeader().setAttribute(HeaderAttributeConstants.PARTITION, String.valueOf(partition));
           record.getHeader().setAttribute(HeaderAttributeConstants.OFFSET, String.valueOf(offset));
+          if (conf.timestampsEnabled) {
+            record
+                .getHeader()
+                .setAttribute(HeaderAttributeConstants.KAFKA_TIMESTAMP, String.valueOf(timestamp));
+            record
+                .getHeader()
+                .setAttribute(HeaderAttributeConstants.KAFKA_TIMESTAMP_TYPE, timestampType);
+          }
 
           try {
             MessageKeyUtil.handleMessageKey(messageKey,

--- a/kafka_multisource-protolib/src/main/resources/upgrader/MultiKafkaDSource.yaml
+++ b/kafka_multisource-protolib/src/main/resources/upgrader/MultiKafkaDSource.yaml
@@ -28,3 +28,7 @@ upgrades:
       - setConfig:
           name: conf.keyCaptureField
           value: /kafkaMessageKey
+      - setConfig:
+          name: conf.timestampsEnabled
+          value: false
+


### PR DESCRIPTION
In Kafka Consumer, we can get record timestamp and timestamp type if set Include Timestamps property to true. But not yet in Kafka Multitopic Consumer.