### PR TITLE
Update azure-lib to allow domain name to be selected.

### DIFF
--- a/azure-lib/src/main/java/com/streamsets/pipeline/lib/eventhubs/EventHubCommon.java
+++ b/azure-lib/src/main/java/com/streamsets/pipeline/lib/eventhubs/EventHubCommon.java
@@ -37,6 +37,7 @@ public class EventHubCommon {
     final ConnectionStringBuilder connStr = new ConnectionStringBuilder()
         .setNamespaceName(commonConf.namespaceName)
         .setEventHubName(commonConf.eventHubName)
+        .setEndpoint(commonConf.namespaceName, commonConf.domainName)
         .setSasKey(commonConf.sasKey)
         .setSasKeyName(commonConf.sasKeyName);
 

--- a/azure-lib/src/main/java/com/streamsets/pipeline/lib/eventhubs/EventHubConfigBean.java
+++ b/azure-lib/src/main/java/com/streamsets/pipeline/lib/eventhubs/EventHubConfigBean.java
@@ -44,6 +44,17 @@ public class EventHubConfigBean {
   @ConfigDef(
       required = true,
       type = ConfigDef.Type.STRING,
+      label = "Environment Domain Name",
+      defaultValue = "",
+      description = "Domain name of the Azure environment",
+      displayPosition = 20,
+      group = "EVENT_HUB"
+  )
+  public String domainName = "";
+
+  @ConfigDef(
+      required = true,
+      type = ConfigDef.Type.STRING,
       label = "Shared Access Policy Name",
       defaultValue = "",
       description = "Name of a shared access policy associated with the namespace",


### PR DESCRIPTION
Currently StreamSets does not allow the Azure Environment domain name to be selected, which means it will not work with non-public national clouds (e.g. usgovcloudapi.net). By default the public cloud domain name is used.

The azure-lib was updated to use the setEndpoint method and a new definition was added to allow the domain name to be entered in the UI.

 See the following Microsoft documentation for more info:
https://docs.microsoft.com/en-us/java/api/com.microsoft.azure.eventhubs.connectionstringbuilder.setendpoint?view=azure-java-stable