### PR TITLE
Fixed TLS config init for WebSocket Origin

### DIFF
--- a/basic-lib/src/main/java/com/streamsets/pipeline/stage/origin/websocket/WebSocketClientDSource.java
+++ b/basic-lib/src/main/java/com/streamsets/pipeline/stage/origin/websocket/WebSocketClientDSource.java
@@ -39,11 +39,7 @@ import com.streamsets.pipeline.lib.websocket.WebSocketOriginGroups;
     upgraderDef = "upgrader/WebSocketClientDSource.yaml"
 )
 @HideConfigs({
-    "conf.dataFormatConfig.jsonContent",
-    "conf.tlsConfig.keyStoreFilePath",
-    "conf.tlsConfig.keyStoreType",
-    "conf.tlsConfig.keyStorePassword",
-    "conf.tlsConfig.keyStoreAlgorithm"
+    "conf.dataFormatConfig.jsonContent"
 })
 @ConfigGroups(WebSocketOriginGroups.class)
 @GenerateResourceBundle

--- a/basic-lib/src/main/java/com/streamsets/pipeline/stage/origin/websocket/WebSocketClientSource.java
+++ b/basic-lib/src/main/java/com/streamsets/pipeline/stage/origin/websocket/WebSocketClientSource.java
@@ -114,6 +114,15 @@ public class WebSocketClientSource implements PushSource {
       ));
     }
 
+    if (issues.isEmpty() && conf.tlsConfig.isEnabled()) {
+      conf.tlsConfig.init(
+          context,
+          Groups.TLS.name(),
+          "conf.tlsConfig.",
+          issues
+      );
+    }
+
     webSocketClient = WebSocketCommon.createWebSocketClient(conf.resourceUrl, conf.tlsConfig);
     webSocketClient.setMaxIdleTimeout(0);
 


### PR DESCRIPTION
This also enables the keystore config, to support mutual TLS connections
which require a keystore.