### PR TITLE
SDC-12512 Bug Fix

### DIFF
--- a/container/src/main/java/com/streamsets/datacollector/execution/runner/standalone/StandaloneRunner.java
+++ b/container/src/main/java/com/streamsets/datacollector/execution/runner/standalone/StandaloneRunner.java
@@ -369,7 +369,8 @@ public class StandaloneRunner extends AbstractRunner implements StateListener {
         int numBatches = configuraton.get(SNAPSHOT_NUM_BATCHES, SNAPSHOT_NUM_BATCHES_DEFAULT);
         int batchSize = configuraton.get(SNAPSHOT_BATCH_SIZE, SNAPSHOT_BATCH_SIZE_DEFAULT);
         LOG.info("Capturing " + numBatches + " batches of snapshot with size " + batchSize);
-        startAndCaptureSnapshot(context, "default", "default", numBatches, batchSize);
+        String uuid = UUID.randomUUID().toString();
+        startAndCaptureSnapshot(context, "default_"+uuid, "default_"+uuid, numBatches, batchSize);
       } else {
         start(context);
       }


### PR DESCRIPTION
Pipelines (which were running before restart) are stuck in state `Starting`.
The root cause is that the snapshot name is always "default", so it will cause an Exception, and the state will not change.
I change the snapshot name, and add the uuid to the name. 
So it will work correctly. And the pipeline state will change to "Running".