### PR TITLE
Update RecordWriterManager.java

### DIFF
--- a/hdfs-protolib/src/main/java/com/streamsets/pipeline/stage/destination/hdfs/writer/RecordWriterManager.java
+++ b/hdfs-protolib/src/main/java/com/streamsets/pipeline/stage/destination/hdfs/writer/RecordWriterManager.java
@@ -296,7 +296,7 @@ public class RecordWriterManager {
       LOG.debug("Path[{}] - Create writer,  time to live '{}ms'", tempPath, writerTimeToLive);
       writer = createWriter(fs, tempPath, writerTimeToLive);
     } else {
-      LOG.warn("Path[{}] - Cannot not create writer, requested date already cut off", tempPath);
+      LOG.warn("Path[{}] - Cannot create writer, requested date already cut off", tempPath);
     }
     return writer;
   }


### PR DESCRIPTION
Update Error message in case of Create Writer failure. Earlier it was "Cannot not"; now it is updated to "Cannot" only. Gives meaningful error. Got this in Production, hence suggesting. Thanks!