### PR TITLE
JdbcGenericRecordWriter not reusing statements for update operations

### DIFF
--- a/jdbc-protolib/src/main/java/com/streamsets/pipeline/lib/jdbc/JdbcGenericRecordWriter.java
+++ b/jdbc-protolib/src/main/java/com/streamsets/pipeline/lib/jdbc/JdbcGenericRecordWriter.java
@@ -48,6 +48,7 @@ import java.util.Map;
 import static com.streamsets.pipeline.lib.jdbc.JdbcErrors.JDBC_14;
 import static com.streamsets.pipeline.lib.operation.OperationType.DELETE_CODE;
 import static com.streamsets.pipeline.lib.operation.OperationType.INSERT_CODE;
+import static com.streamsets.pipeline.lib.operation.OperationType.UPDATE_CODE;
 
 public class JdbcGenericRecordWriter extends JdbcBaseRecordWriter {
   private static final Logger LOG = LoggerFactory.getLogger(JdbcGenericRecordWriter.class);
@@ -147,7 +148,7 @@ public class JdbcGenericRecordWriter extends JdbcBaseRecordWriter {
 
         boolean opCodeValid = opCode > 0;
         boolean opCodeUnchanged = opCode == prevOpCode;
-        boolean supportedOpCode = opCode == DELETE_CODE || opCode == INSERT_CODE && columnHash.equals(prevColumnHash);
+        boolean supportedOpCode = opCode == DELETE_CODE || ((opCode == UPDATE_CODE || opCode == INSERT_CODE) && columnHash.equals(prevColumnHash));
         boolean canEnqueue = opCodeValid && opCodeUnchanged && supportedOpCode;
 
         if (canEnqueue) {


### PR DESCRIPTION
Update operations with same columns can be 'enqueued' so a single PreparedStatement will be created and used.