### PR TITLE
SobjectRecordCreator.createField() NPE for base64 field type with null value 

### DIFF
--- a/salesforce-lib/src/main/java/com/streamsets/pipeline/lib/salesforce/SobjectRecordCreator.java
+++ b/salesforce-lib/src/main/java/com/streamsets/pipeline/lib/salesforce/SobjectRecordCreator.java
@@ -479,8 +479,11 @@ public abstract class SobjectRecordCreator extends ForceRecordCreatorImpl {
       } else if (STRING_TYPES.contains(sfdcType)) {
         return  com.streamsets.pipeline.api.Field.create(com.streamsets.pipeline.api.Field.Type.STRING, val);
       } else if (BINARY_TYPES.contains(sfdcType)) {
-        return  com.streamsets.pipeline.api.Field.create(com.streamsets.pipeline.api.Field.Type.BYTE_ARRAY,
-            Base64.getDecoder().decode((String)val));
+        byte[] bytes = new byte[0];
+        if (val != null) {
+          bytes = Base64.getDecoder().decode((String)val);
+        }
+        return com.streamsets.pipeline.api.Field.create(com.streamsets.pipeline.api.Field.Type.BYTE_ARRAY, bytes);
       } else if (DATETIME_TYPES.contains(sfdcType)) {
         if (val != null && !(val instanceof String)) {
           throw new StageException(

--- a/salesforce-lib/src/test/java/com/streamsets/pipeline/lib/salesforce/TestSobjectRecordCreator.java
+++ b/salesforce-lib/src/test/java/com/streamsets/pipeline/lib/salesforce/TestSobjectRecordCreator.java
@@ -1,0 +1,19 @@
+package com.streamsets.pipeline.lib.salesforce;
+
+import com.sforce.soap.partner.Field;
+import com.sforce.soap.partner.FieldType;
+import com.streamsets.pipeline.api.StageException;
+import org.junit.Test;
+
+public class TestSobjectRecordCreator {
+    @Test
+    public void whenByteArrayNullCreateFieldFailsWithNPE() throws StageException {
+        SoapRecordCreator recordCreator = new SoapRecordCreator( null, null, "Attachment" );
+
+        Object val = null;
+        Field sfdcField = new Field();
+        sfdcField.setType( FieldType.base64 );
+        recordCreator.createField(null , val, DataType.USE_SALESFORCE_TYPE, sfdcField );
+    }
+}
+


### PR DESCRIPTION
A base64 Salesforce field type with a null value results in a NullPointerException when SobjectRecordCreator.createField() is called