### PR TITLE
Clean up false-positive error logs for MS SQL CDC

### DIFF
--- a/jdbc-protolib/src/main/java/com/streamsets/pipeline/lib/jdbc/JdbcUtil.java
+++ b/jdbc-protolib/src/main/java/com/streamsets/pipeline/lib/jdbc/JdbcUtil.java
@@ -419,6 +419,11 @@ public class JdbcUtil {
     for (String offsetColumn : offsetColumnNames) {
       final String qualifiedOffsetColumn = TableContextUtil.getQuotedObjectName(offsetColumn, quoteChar.getQuoteCharacter());
       final String minMaxOffsetQuery = String.format(minMaxQuery, qualifiedOffsetColumn, qualifiedTableName);
+      
+      if (vendor == DatabaseVendor.SQL_SERVER && qualifiedOffsetColumn == "__$sdc.txn_window"){
+        continue;
+      }
+      
       LOG.debug("Issuing {} offset query: {}",
             minMaxQuery.equals(MIN_OFFSET_VALUE_QUERY) ? "MINIMUM" : "MAXIMUM", minMaxOffsetQuery);
       try (


### PR DESCRIPTION
Without this change logs have thousands of false positive messages that pipeline is exausted. The issue is that "__$sdc.txn_window" is not available in MS SQL and should not be attempted. Ideally solution will be to check column presence in target table with TableContext and skip execution if not founded.