### PR TITLE
SDC-12269 MSSQL CDC get stuck after clean up job

### DIFF
--- a/jdbc-protolib/src/main/java/com/streamsets/pipeline/lib/jdbc/multithread/util/MSQueryUtil.java
+++ b/jdbc-protolib/src/main/java/com/streamsets/pipeline/lib/jdbc/multithread/util/MSQueryUtil.java
@@ -240,6 +240,7 @@ public final class MSQueryUtil {
     String captureInstanceName = tableName.substring("cdc.".length(), tableName.length() - "_CT".length());
     StringBuilder query = new StringBuilder();
     String declare_from_lsn;
+    String declare_from_lsn_min = "";
     String declare_to_lsn;
     String declare_to_lsn2 = "";
     String where_clause;
@@ -287,6 +288,9 @@ public final class MSQueryUtil {
       declare_from_lsn = String.format("DECLARE @start_lsn binary(10) = 0x%s; ",
           offsetMap.get(CDC_START_LSN));
 
+      declare_from_lsn_min = String.format("DECLARE @min_lsn binary(10) = sys.fn_cdc_get_min_lsn (N'%s') if (@min_lsn > @start_lsn) BEGIN SET @start_lsn = @min_lsn END ",
+          captureInstanceName
+      
       String cdcOperation = Strings.isNullOrEmpty(offsetMap.get(CDC_OPERATION)) ? "2" : offsetMap.get(CDC_OPERATION);
 
       String condition1 = String.format(
@@ -325,6 +329,7 @@ public final class MSQueryUtil {
 
 
     query.append(declare_from_lsn);
+    query.append(declare_from_lsn_min);
     query.append(declare_to_lsn);
     query.append(declare_to_lsn2);
 


### PR DESCRIPTION
MSSQL CDC perfrom clean up job every 24 hours and removes 5000 records that are older than 72 hours by default. This behaviour is a subject of change but in vast majority of use cases clean up is performed for better cloud storage utilization.

After clean up tables may lost all the cdc records available and newly added would have $start_lsn higher than was cached by Streamsets. The most common workaround is to "Reset origin" for the pipeline which would cause cache clean-up, However in production scenarious constant manual interventions is not expected behavior.

Well known MS function cdc.fn_cdc_get_net_changes_<capture_instance> (https://docs.microsoft.com/en-us/sql/relational-databases/system-functions/cdc-fn-cdc-get-net-changes-capture-instance-transact-sql?view=sql-server-ver15) will throw error if  one of the input values is not available (from_lsn or to_lsn). This eventually caused pipeline getting stuck and flood billlions of errors.

Solution is to adopt check that from_to is picked up either from cache or MS SQL. In case MSSQL LSN is higher it will be given favour comparing with cached. That will allow pipeline to keep moving without manual "Reset Origin" step.