### PR TITLE
SDC-13170: Capture Azure Event Hub message header in record header

### DIFF
--- a/azure-lib/src/main/java/com/streamsets/pipeline/stage/origin/eventhubs/EventHubProcessor.java
+++ b/azure-lib/src/main/java/com/streamsets/pipeline/stage/origin/eventhubs/EventHubProcessor.java
@@ -29,6 +29,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -78,7 +79,11 @@ public class EventHubProcessor implements IEventProcessor {
         try (DataParser parser = dataParserFactory.getParser(requestId, eventData.getBytes())) {
           Record parsedRecord = parser.parse();
           while (parsedRecord != null) {
-            records.add(parsedRecord);
+            Map<String, Object> messageProperties = eventData.getProperties();
+            Record finalParsedRecord = parsedRecord;
+            messageProperties.forEach((key, value) -> finalParsedRecord.getHeader().setAttribute(key, value == null ? "" : value.toString()));
+
+            records.add(finalParsedRecord);
             parsedRecord = parser.parse();
           }
           for (Record record : records) {


### PR DESCRIPTION
Hi, this small change implements SDC-13170 (https://issues.streamsets.com/browse/SDC-13170) and includes any information in the properties field of the message - outside of the payload field - in records as record header attributes, similar to the support in the Pulsar origin. 

Have tested it using Azure IoT Hub and it works.