### PR TITLE
SDC-16714. Fix moment.js vulnerabilities by update to latest version.

### DIFF
--- a/datacollector-ui/bower.json
+++ b/datacollector-ui/bower.json
@@ -20,7 +20,7 @@
     "underscore": "1.8.3",
     "fontawesome": "~4.2.0",
     "angular-moment": "1.3.0",
-    "moment": "2.9.0",
+    "moment": "2.29.1",
     "nvd3": "1.8.4",
     "angular-ui-select": "0.13.2",
     "ngstorage": "0.3.7",
@@ -35,7 +35,6 @@
   "resolutions": {
     "angular": "1.7.7",
     "angular-cookies": "1.7.7",
-    "d3": "3.5.6",
-    "moment": "2.9.0"
+    "d3": "3.5.6"
   }
 }


### PR DESCRIPTION
Old version of Moment.js 2.9.0 was added some time ago as main dependency
and set in force resolutions section has known vulnerabilities
(see https://snyk.io/vuln/npm:moment@2.9.0).

This fix removes dependency for old version of moment 2.9.0 in
force resolutions section and updates main dependency version to
moment 2.29.1 which is also used by angular-moment 1.3.0.